### PR TITLE
Bug/cutout depth

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
@@ -7,9 +7,16 @@
 #if defined(_TRANSPARENCY_BY_RIM) || defined(_TINT_AREA_RIM)
 #define FRAGMENT_USE_VIEW_DIR_WS
 #endif
-#if defined(_TRANSPARENCY_BY_RIM) || defined(_TINT_AREA_RIM)
+#if defined(_TRANSPARENCY_BY_RIM) || defined(_TINT_AREA_RIM) || defined(DEPTH_NORMALS_PASS)
 #define FRAGMENT_USE_NORMAL_WS
 #endif
+
+#if defined(DEPTH_ONLY_PASS)
+#ifndef _ALPHATEST_ENABLED
+#undef FRAGMENT_USE_NORMAL_WS // This symbol is not necessary when drawing opaque objects.
+#endif
+#endif
+
 #if defined(_SOFT_PARTICLES_ENABLED) || defined(_DEPTH_FADE_ENABLED)
 #define USE_PROJECTED_POSITION
 #endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
@@ -3,6 +3,7 @@
 
 #include "ParticlesUber.hlsl"
 
+
 struct Attributes
 {
     float4 positionOS : POSITION;
@@ -40,7 +41,7 @@ struct Varyings
 struct AttributesDrawDepth
 {
     float4 positionOS : POSITION;
-    #ifdef DEPTH_NORMALS_PASS
+    #ifdef FRAGMENT_USE_NORMAL_WS
     float3 normalOS : NORMAL;
     #endif
     #ifdef _ALPHATEST_ENABLED // This attributes is not used for opaque objects.
@@ -57,7 +58,7 @@ struct AttributesDrawDepth
 struct VaryingsDrawDepth
 {
     float4 positionHCS : SV_POSITION;
-    #ifdef DEPTH_NORMALS_PASS
+    #ifdef FRAGMENT_USE_NORMAL_WS
     float3 normalWS : NORMAL;
     #endif
     #ifdef _ALPHATEST_ENABLED // This attributes is not used for opaque objects.
@@ -110,7 +111,7 @@ inline void InitializeFragmentInput(in out Varyings input)
 inline void InitializeVertexOutputDrawDepth(in AttributesDrawDepth input, in out VaryingsDrawDepth output)
 {
     output.positionHCS = TransformObjectToHClip(input.positionOS.xyz);
-    #ifdef DEPTH_NORMALS_PASS
+    #ifdef FRAGMENT_USE_NORMAL_WS
     output.normalWS = TransformObjectToWorldNormal(input.normalOS, true);
     #endif
 
@@ -129,13 +130,12 @@ inline void InitializeVertexOutputDrawDepth(in AttributesDrawDepth input, in out
 
 inline void InitializeFragmentInputDrawDepth(in out VaryingsDrawDepth input)
 {
-    
-    #ifdef DEPTH_NORMALS_PASS
+    #ifdef FRAGMENT_USE_NORMAL_WS
     input.normalWS = normalize(input.normalWS);
     #endif
 
     #ifdef _ALPHATEST_ENABLED // This code is not used for opaque objects.
-    #if FRAGMENT_USE_VIEW_DIR_WS 
+    #ifdef FRAGMENT_USE_VIEW_DIR_WS 
     input.viewDirWS = normalize(input.viewDirWS);
     #endif
     #endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.shader
@@ -137,8 +137,7 @@ Shader "Nova/Particles/UberUnlit"
             ZTest LEqual
 
             HLSLPROGRAM
-
-            #pragma enable_d3d11_debug_symbols
+            
             #pragma vertex vert
             #pragma fragment frag
             #pragma target 3.5
@@ -349,7 +348,7 @@ Shader "Nova/Particles/UberUnlit"
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS
             // NOTE : Not need in DepthNormals pass.
             // #pragma shader_feature_local_fragment _ALPHAMODULATE_ENABLED
-            #pragma shader_feature_local_fragment _ALPHATEST_ENABLED
+            #pragma shader_feature_local _ALPHATEST_ENABLED
 
             // Base Map
             #pragma shader_feature_local _BASE_MAP_MODE_2D _BASE_MAP_MODE_2D_ARRAY _BASE_MAP_MODE_3D
@@ -416,7 +415,7 @@ Shader "Nova/Particles/UberUnlit"
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS
             // NOTE : Not need in DepthNormals pass.
             // #pragma shader_feature_local_fragment _ALPHAMODULATE_ENABLED
-            #pragma shader_feature_local_fragment _ALPHATEST_ENABLED
+            #pragma shader_feature_local _ALPHATEST_ENABLED
 
             // Base Map
             #pragma shader_feature_local _BASE_MAP_MODE_2D _BASE_MAP_MODE_2D_ARRAY _BASE_MAP_MODE_3D


### PR DESCRIPTION
- Cutoutにすると深度が書き込まれない不具合
fdbb18c500911da47c1b660ceb9d7adf7e79f3c9 で修正しました。
_ALPHATEST_ENABLEDがフラグメントシェーダーのみで有効になっていたため、頂点シェーダーでの_ALPHATEST_ENABLEDで条件コンパイルが意図通り動作していませんでした（ParticlesUberUnlitDepthNormalsCore.hlslのvert()関数）
このため、フラグメントシェーダーで値が設定されていないパラメータにアクセスしており、意図しない結果になっていました。
そこで、頂点シェーダー/フラグメントシェーダーの両方で_ALPHATEST_ENABLEDを使えるように、DepthNormalsとDepthOnlyの#pragmaを変更しました。
Cutout/Opaqueともに正しく動作していることを確認しました。
あと、別件で前回のバグ修正の際にデバッグ用のコードを追加したままアップしてしまっていたので、こちらも削除しました。
![cutout_depth](https://user-images.githubusercontent.com/106138524/177247180-8b1f2e21-aa6e-40e1-b67f-e5ccd2417d0e.png)

- Cutout+Rimにするとピンクになってしまう不具合(コンパイルエラーが起きていた)
46cc850010eead69e350d9939012a65f0b061554 で修正しました。
リムを計算する際に法線が必要になるのですが、DEPTH_NORMAL_PASSが有効の時しか法線を定義にしておらず、リムを計算する際に定義していない法線を使っている箇所でコンパイルエラーが起きていました。
法線の定義を他の個所と合わせて、FRAGMENT_USE_NORMAL_WSを利用するように変更しました。
それに合わせて、FRAGMENT_USE_NORMAL_WSがDEPTH_NORMALS_PASSが定義されているときにも有効になるように変更しました。
ただ、DEPTH_ONLY_PASSで不透明オブジェクトを描画する際にも、法線が有効になるケースがあるため（リムを使うとき)、その場合はいらないアトリビュートとなってしまい、無駄な処理が走ってしまうので、その場合は#undefでシンボルを消しています。

レビューよろしくお願いします。