### PR TITLE
Feature/uber lit bug fix

### DIFF
--- a/Assets/Nova/Runtime/Core/Scripts/ScreenSpaceDistortion.cs
+++ b/Assets/Nova/Runtime/Core/Scripts/ScreenSpaceDistortion.cs
@@ -1,5 +1,5 @@
 // --------------------------------------------------------------
-// Copyright 2021 CyberAgent, Inc.
+// Copyright 2022 CyberAgent, Inc.
 // --------------------------------------------------------------
 
 using System;
@@ -23,10 +23,7 @@ namespace Nova.Runtime.Core.Scripts
         public override void Create()
         {
             _applyDistortionShader = Shader.Find("Hidden/Nova/Particles/ApplyDistortion");
-            if (_applyDistortionShader == null)
-            {
-                return;
-            }
+            if (_applyDistortionShader == null) return;
 
             _distortedUvBufferPass = new DistortedUvBufferPass(DistortionLightMode);
             _applyDistortionPass = new ApplyDistortionPass(_applyToSceneView, _applyDistortionShader);
@@ -34,17 +31,15 @@ namespace Nova.Runtime.Core.Scripts
 
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
-            if (_applyDistortionShader == null)
-            {
-                return;
-            }
-
+            if (_applyDistortionShader == null) return;
             var cameraTargetDesciptor = renderingData.cameraData.cameraTargetDescriptor;
+
             var distortedUvBufferFormat = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.RGHalf)
                 ? RenderTextureFormat.RGHalf
                 : RenderTextureFormat.DefaultHDR;
             var distortedUvBuffer = RenderTexture.GetTemporary(cameraTargetDesciptor.width,
-                cameraTargetDesciptor.height, 0, distortedUvBufferFormat);
+                cameraTargetDesciptor.height, 0, distortedUvBufferFormat, RenderTextureReadWrite.Default,
+                cameraTargetDesciptor.msaaSamples);
             var distortedUvBufferIdentifier = new RenderTargetIdentifier(distortedUvBuffer);
 
             _distortedUvBufferPass.Setup(distortedUvBufferIdentifier, () => renderer.cameraDepthTarget);

--- a/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
@@ -17,6 +17,15 @@
 #endif
 #endif
 
+#if defined(DEPTH_ONLY_PASS) || defined(DEPTH_NORMALS_PASS)
+#ifndef _ALPHATEST_ENABLED
+// These symbols are not necessary when drawing opaque objects.
+#undef FRAGMENT_USE_VIEW_DIR_WS 
+#undef _TRANSPARENCY_BY_RIM
+#undef _TINT_AREA_RIM
+#endif
+#endif
+
 #if defined(_SOFT_PARTICLES_ENABLED) || defined(_DEPTH_FADE_ENABLED)
 #define USE_PROJECTED_POSITION
 #endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
@@ -268,6 +268,10 @@ half4 frag(VaryingsDrawDepth input) : SV_Target
     
     InitializeFragmentInputDrawDepth(input);
 
+    #if defined(_TRANSPARENCY_BY_RIM) || defined(_TINT_AREA_RIM)
+    half rim = 1.0 - abs(dot(input.normalWS, input.viewDirWS));
+    #endif
+    
     // Flow map 
     #if defined( _USE_FLOW_MAP)
     half intensity = _FlowIntensity + GET_CUSTOM_COORD(_FlowIntensityCoord);

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
@@ -175,11 +175,19 @@ Shader "Nova/Particles/UberLit"
             #pragma instancing_options procedural:ParticleInstancingSetup
             #pragma require 2darray
 
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            
             // Render Settings
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS
             #pragma shader_feature_local_fragment _ALPHAMODULATE_ENABLED
             #pragma shader_feature_local_fragment _ALPHATEST_ENABLED
-            #pragma shader_feature_local _MAIN_LIGHT_CALCULATE_SHADOWS
+            
             #pragma shader_feature_local _RECEIVE_SHADOWS_ENABLED
             #pragma shader_feature_local _SPECULAR_HIGHLIGHTS_ENABLED
             #pragma shader_feature_local _ENVIRONMENT_REFLECTIONS_ENABLED
@@ -256,7 +264,6 @@ Shader "Nova/Particles/UberLit"
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS
             #pragma shader_feature_local_fragment _ALPHAMODULATE_ENABLED
             #pragma shader_feature_local_fragment _ALPHATEST_ENABLED
-            #pragma shader_feature_local _MAIN_LIGHT_CALCULATE_SHADOWS
 
             // Base Map
             #pragma shader_feature_local _BASE_MAP_MODE_2D _BASE_MAP_MODE_2D_ARRAY _BASE_MAP_MODE_3D

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
@@ -4,6 +4,7 @@
 //////////////////////////////////////////
 // Define symbols for URP Functions.
 //////////////////////////////////////////
+
 #ifndef _SPECULAR_HIGHLIGHTS_ENABLED
 #define _SPECULARHIGHLIGHTS_OFF
 #endif
@@ -16,11 +17,10 @@
 #define _NORMALMAP
 #endif
 
-#ifdef _RECEIVE_SHADOWS_ENABLED
-#define MAIN_LIGHT_CALCULATE_SHADOWS
+#ifndef _RECEIVE_SHADOWS_ENABLED
+#define _RECEIVE_SHADOWS_OFF
 #endif
 
-#define _ADDITIONAL_LIGHTS
 #define REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR
 
 //////////////////////////////////////////


### PR DESCRIPTION
下記の三つのバグを修正しました。

- 9aeaeca906952f8ca63569e0d9d5c4f79892b203 DepthOnly, DepthNormalsパスで不要な時もリムの処理が有効になっていた
- 0e35cc82d23b1d2b87015a05985588c865270bce Galaxy S10eで発生していた表示バグ
- d4605f488bcae4aa74a3e7091b2d9560990a0b1b MSAAを有効にしたときに、実機( pixel6 pro )で表示バグが起きていた

9aeaeca906952f8ca63569e0d9d5c4f79892b203 
DepthOnly,DepthNormalパスで不透明オブジェクトを描画する際は、リムの処理は不要なのですがコードが残ってしまっていました。そのため、存在しないアトリビュートにアクセスることになってしまい、コンパイルエラーが起きていました。
DepthOnly,DepthNormalパスの際に、リムの機能のためのシンボルをundefするように変更しました。

0e35cc82d23b1d2b87015a05985588c865270bce 
シーンにシャドウキャスターとなっているオブジェクトが存在していないときに、UberLitシェーダーのRecieve Shadowsがオンになっていると、一部の端末( Galaxy S10eなど )で表示バグが起きていました。
URPのParticle/Litでは、シャドウキャスターがいない場合は影を落とす処理が無効になるようになっていたのですが、UberLitの方は有効のままとなっており、これによって発生していた不具合です。
UberLitの影のオンオフの切り替えが、URPのParticle/Litと同様になるように修正しました。

2022/8/25 追記
d4605f488bcae4aa74a3e7091b2d9560990a0b1b
lit版によって起きている不具合ではないですが、FSRの検証の際にMSAAを有効にすると、Android端末で絵が表示されなくなる不具合が起きていました。
原因は、下記の個所でUVBufferと、カメラに設定されているデプスバッファをレンダリングターゲットとして設定していますが、MSAAが有効になると、この二つのテクスチャでマルチサンプリング数の差異が生まれているため、レンダリングターゲットの設定に失敗していることのようでした。

https://github.com/CyberAgentGameEntertainment/NovaShader/blob/fa4e6acf2781bef6043f074605d773c717a93319/Assets/Nova/Runtime/Core/Scripts/DistortedUvBufferPass.cs#L41-L42

そこでUVBufferを作成する際に、カメラのレンダリングターゲットのマルチサンプリング数を利用して、作成するようにコードを変更してます。

モバイルでMSAAを有効にすることはパフォーマンスの問題から、ほぼないかと思いますが、副作用など起きない修正だと判断したので修正を入れました。