### PR TITLE
Feature/fix now button

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
@@ -3,9 +3,12 @@
 // --------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Nova.Editor.Foundation.Scripts;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Nova.Editor.Core.Scripts
 {
@@ -14,10 +17,185 @@ namespace Nova.Editor.Core.Scripts
     /// </summary>
     internal class ParticlesUberCommonGUI
     {
+        public ParticlesUberCommonGUI(MaterialEditor editor)
+        {
+            var material = editor.target as Material;
+            CacheRenderersUsingThisMaterial(material);
+        }
+
+        private bool IsEnabledGPUInstancing(ParticleSystemRenderer particleSystem)
+        {
+            return particleSystem.enableGPUInstancing && particleSystem.renderMode == ParticleSystemRenderMode.Mesh;
+        }
+
+        private bool IsCustomCoordUsed(ParticlesGUI.Property prop)
+        {
+            return (CustomCoord)prop.Value.floatValue !=
+                   CustomCoord.Unused;
+        }
+
+        private bool IsCustomCoordUsedInBaseMap()
+        {
+            var isCustomCoordUsed = IsCustomCoordUsed(_commonMaterialProperties.BaseMapOffsetXCoordProp)
+                                    || IsCustomCoordUsed(_commonMaterialProperties.BaseMapOffsetYCoordProp)
+                                    || IsCustomCoordUsed(_commonMaterialProperties.BaseMapRotationCoordProp)
+                                    || IsCustomCoordUsed(_commonMaterialProperties.BaseMapRotationCoordProp);
+            isCustomCoordUsed |= (BaseMapMode)_commonMaterialProperties.BaseMapModeProp.Value.floatValue !=
+                                 BaseMapMode.SingleTexture
+                                 && IsCustomCoordUsed(_commonMaterialProperties.BaseMapProgressProp);
+
+            isCustomCoordUsed |= (BaseMapMode)_commonMaterialProperties.BaseMapModeProp.Value.floatValue !=
+                                 BaseMapMode.SingleTexture
+                                 && IsCustomCoordUsed(_commonMaterialProperties.BaseMapProgressCoordProp);
+
+            return isCustomCoordUsed;
+        }
+
+        private bool IsCustomCoordUsedInTintColor()
+        {
+            var isCustomCoordUsed = false;
+            var tintAreaMode = (TintAreaMode)_commonMaterialProperties.TintAreaModeProp.Value.floatValue;
+            if (tintAreaMode != TintAreaMode.None)
+            {
+                isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.TintMapBlendRateCoordProp);
+                if (tintAreaMode == TintAreaMode.Rim)
+                    isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.TintRimProgressCoordProp)
+                                         || IsCustomCoordUsed(_commonMaterialProperties.TintRimSharpnessCoordProp);
+
+                var tintMapMode = (TintColorMode)_commonMaterialProperties.TintColorModeProp.Value.floatValue;
+                if (tintMapMode == TintColorMode.Texture3D)
+                    isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.TintMap3DProgressCoordProp);
+            }
+
+            return isCustomCoordUsed;
+        }
+
+        private bool IsCustomCoordUsedInFlowMap()
+        {
+            return IsCustomCoordUsed(_commonMaterialProperties.FlowMapOffsetXCoordProp)
+                   || IsCustomCoordUsed(_commonMaterialProperties.FlowMapOffsetYCoordProp)
+                   || IsCustomCoordUsed(_commonMaterialProperties.FlowIntensityCoordProp);
+        }
+
+        private bool IsCustomCoordUsedInAlphaTransition()
+        {
+            var mode = (AlphaTransitionMode)_commonMaterialProperties.AlphaTransitionModeProp.Value.floatValue;
+            if (mode == AlphaTransitionMode.None) return false;
+            var isCustomCoordUsed = false;
+            isCustomCoordUsed = IsCustomCoordUsed(_commonMaterialProperties.AlphaTransitionProgressCoordProp);
+            isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.AlphaTransitionMapOffsetXCoordProp)
+                                 || IsCustomCoordUsed(_commonMaterialProperties.AlphaTransitionMapOffsetYCoordProp);
+            isCustomCoordUsed |=
+                (AlphaTransitionMapMode)_commonMaterialProperties.AlphaTransitionMapModeProp.Value.floatValue !=
+                AlphaTransitionMapMode.SingleTexture
+                && IsCustomCoordUsed(_commonMaterialProperties.AlphaTransitionMapProgressCoordProp);
+            return isCustomCoordUsed;
+        }
+
+        private bool IsCustomCoordUsedInEmission()
+        {
+            var mode = (EmissionAreaType)_commonMaterialProperties.EmissionAreaTypeProp.Value.floatValue;
+            if (mode == EmissionAreaType.None) return false;
+            var isCustomCoordUsed = false;
+            isCustomCoordUsed = IsCustomCoordUsed(_commonMaterialProperties.EmissionIntensityCoordProp);
+            if (mode == EmissionAreaType.ByTexture)
+            {
+                isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.EmissionMapOffsetXCoordProp)
+                                     || IsCustomCoordUsed(_commonMaterialProperties.EmissionMapOffsetYCoordProp);
+                isCustomCoordUsed |= (EmissionMapMode)_commonMaterialProperties.EmissionMapModeProp.Value.floatValue !=
+                                     EmissionMapMode.SingleTexture
+                                     && IsCustomCoordUsed(_commonMaterialProperties.EmissionMapProgressCoordProp);
+            }
+
+            return isCustomCoordUsed;
+        }
+
+        private bool IsCustomCoordUsedInTransparency()
+        {
+            var isCustomCoordUsed = false;
+            var enabledRim = _commonMaterialProperties.RimTransparencyEnabledProp.Value.floatValue > 0.5f;
+            if (enabledRim)
+            {
+                isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.RimTransparencyProgressCoordProp);
+                isCustomCoordUsed |= IsCustomCoordUsed(_commonMaterialProperties.RimTransparencySharpnessCoordProp);
+            }
+
+            var enabledLuminance = _commonMaterialProperties.LuminanceTransparencyEnabledProp.Value.floatValue > 0.5f;
+            if (enabledLuminance)
+            {
+                isCustomCoordUsed |=
+                    IsCustomCoordUsed(_commonMaterialProperties.LuminanceTransparencyProgressCoordProp);
+                isCustomCoordUsed |=
+                    IsCustomCoordUsed(_commonMaterialProperties.LuminanceTransparencySharpnessCoordProp);
+            }
+
+            return isCustomCoordUsed;
+        }
+
+        private bool IsCustomCoordUsed()
+        {
+            if (_commonMaterialProperties == null) return false;
+
+            return IsCustomCoordUsedInBaseMap()
+                   || IsCustomCoordUsedInTintColor()
+                   || IsCustomCoordUsedInFlowMap()
+                   || IsCustomCoordUsedInAlphaTransition()
+                   || IsCustomCoordUsedInEmission()
+                   || IsCustomCoordUsedInTransparency();
+        }
+
+        private void SetupCorrectVertexStreams(Material material)
+        {
+            // Correct vertex streams when enabled GPU Instance.
+            _correctVertexStreamsInstanced.Clear();
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Position);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Normal);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Color);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.UV);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.UV2);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Custom1XYZW);
+            _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Custom2XYZW);
+
+            // Correct vertes streams when disabled GPU Instance. 
+            _correctVertexStreams.Clear();
+            _correctVertexStreams.Add(ParticleSystemVertexStream.Position);
+            _correctVertexStreams.Add(ParticleSystemVertexStream.Normal);
+            _correctVertexStreams.Add(ParticleSystemVertexStream.Color);
+            _correctVertexStreams.Add(ParticleSystemVertexStream.UV);
+            _correctVertexStreams.Add(ParticleSystemVertexStream.UV2);
+
+            // Is custom coord Used ?
+            if (IsCustomCoordUsed())
+            {
+                _correctVertexStreams.Add(ParticleSystemVertexStream.Custom1XYZW);
+                _correctVertexStreams.Add(ParticleSystemVertexStream.Custom2XYZW);
+            }
+
+            if (material.shader.name == "Nova/Particles/UberLit"
+                && material.IsKeywordEnabled(ShaderKeywords.NormalMapEnabled))
+            {
+                _correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Tangent);
+                _correctVertexStreams.Add(ParticleSystemVertexStream.Tangent);
+            }
+        }
+
+        private void CacheRenderersUsingThisMaterial(Material material)
+        {
+            _renderersUsingThisMaterial.Clear();
+
+            var renderers = Object.FindObjectsOfType(typeof(ParticleSystemRenderer)) as ParticleSystemRenderer[];
+            if (renderers == null) return;
+            foreach (var renderer in renderers)
+                if (renderer.sharedMaterial == material)
+                    _renderersUsingThisMaterial.Add(renderer);
+        }
+
         public void Setup(MaterialEditor editor, ParticlesUberCommonMaterialProperties commonMaterialProperties)
         {
             _editor = editor;
             _commonMaterialProperties = commonMaterialProperties;
+            SetupCorrectVertexStreams(_editor.target as Material);
+            
         }
 
         public void DrawRenderSettingsProperties(Action drawPropertiesFunc)
@@ -67,6 +245,52 @@ namespace Nova.Editor.Core.Scripts
         {
             DrawProperties(_commonMaterialProperties.TransparencyFoldout,
                 "Transparency", InternalDrawTransparencyProperties);
+        }
+
+        private static bool CompareVertexStreams(List<ParticleSystemVertexStream> a,
+            List<ParticleSystemVertexStream> b)
+        {
+            if (a.Count != b.Count) return false;
+            for (var i = 0; i < a.Count; i++)
+                if (a[i] != b[i])
+                    return false;
+            return true;
+        }
+
+
+        public void DrawFixNowButton()
+        {
+            var warnings = "";
+
+            var rendererStreams = new List<ParticleSystemVertexStream>();
+            foreach (var renderer in _renderersUsingThisMaterial)
+            {
+                renderer.GetActiveVertexStreams(rendererStreams);
+                var streamsValid = false;
+                if (IsEnabledGPUInstancing(renderer))
+                    streamsValid = CompareVertexStreams(rendererStreams, _correctVertexStreamsInstanced);
+                else
+                    streamsValid = CompareVertexStreams(rendererStreams, _correctVertexStreams);
+                if (!streamsValid)
+                    warnings += $"-{renderer.name}\n";
+            }
+
+            if (string.IsNullOrEmpty(warnings)) return;
+
+            EditorGUILayout.HelpBox(
+                "The following Particle System Renderers are using this material with incorrect Vertex Streams:\n" +
+                warnings, MessageType.Error, true);
+            if (GUILayout.Button(StreamApplyToAllSystemsText, EditorStyles.miniButton,
+                    GUILayout.ExpandWidth(true)))
+            {
+                Undo.RecordObjects(
+                    _renderersUsingThisMaterial.Where(r => r != null).ToArray(),
+                    "Apply custom vertex streams from material");
+                foreach (var renderer in _renderersUsingThisMaterial)
+                    renderer.SetActiveVertexStreams(IsEnabledGPUInstancing(renderer)
+                        ? _correctVertexStreamsInstanced
+                        : _correctVertexStreams);
+            }
         }
 
         public void DrawProperties(BoolEditorPrefsProperty foldout, string categoryName, Action internalDrawFunction)
@@ -446,6 +670,15 @@ namespace Nova.Editor.Core.Scripts
         private const int RenderPriorityMin = -RenderPriorityMax;
         private MaterialEditor _editor;
         private ParticlesUberCommonMaterialProperties _commonMaterialProperties;
+
+        private static readonly GUIContent StreamApplyToAllSystemsText = new GUIContent("Fix Now",
+            "Apply the vertex stream layout to all Particle Systems using this material");
+
+        private readonly List<ParticleSystemRenderer> _renderersUsingThisMaterial = new List<ParticleSystemRenderer>();
+        private List<ParticleSystemVertexStream> _correctVertexStreams = new List<ParticleSystemVertexStream>();
+
+        private List<ParticleSystemVertexStream>
+            _correctVertexStreamsInstanced = new List<ParticleSystemVertexStream>();
 
         # endregion
     }

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
@@ -259,7 +259,7 @@ namespace Nova.Editor.Core.Scripts
 
         public void DrawFixNowButton()
         {
-            var warnings = "";
+            var hasError = false;
 
             var rendererStreams = new List<ParticleSystemVertexStream>();
             foreach (var renderer in _renderersUsingThisMaterial)
@@ -271,14 +271,18 @@ namespace Nova.Editor.Core.Scripts
                 else
                     streamsValid = CompareVertexStreams(rendererStreams, _correctVertexStreams);
                 if (!streamsValid)
-                    warnings += $"-{renderer.name}\n";
+                {
+                    hasError = true;
+                    break;
+                }
             }
 
-            if (string.IsNullOrEmpty(warnings)) return;
+            if (!hasError) return;
 
             EditorGUILayout.HelpBox(
-                "The following Particle System Renderers are using this material with incorrect Vertex Streams:\n" +
-                warnings, MessageType.Error, true);
+                "Some particle System Renderers are using this material with incorrect Vertex Streams.\n" +
+                "Recommend that you press the Fix Now button to correct the error." 
+                , MessageType.Error, true);
             if (GUILayout.Button(StreamApplyToAllSystemsText, EditorStyles.miniButton,
                     GUILayout.ExpandWidth(true)))
             {

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
@@ -195,7 +195,6 @@ namespace Nova.Editor.Core.Scripts
             _editor = editor;
             _commonMaterialProperties = commonMaterialProperties;
             SetupCorrectVertexStreams(_editor.target as Material);
-            
         }
 
         public void DrawRenderSettingsProperties(Action drawPropertiesFunc)
@@ -390,7 +389,7 @@ namespace Nova.Editor.Core.Scripts
                 {
                     MaterialEditorUtility.DrawPropertyAndCustomCoord(
                         _editor, "Progress", props.TintRimProgressProp.Value,
-                        props.TintRimSharpnessCoordProp.Value);
+                        props.TintRimProgressCoordProp.Value);
                     MaterialEditorUtility.DrawPropertyAndCustomCoord(_editor, "Sharpness",
                         props.TintRimSharpnessProp.Value,
                         props.TintRimSharpnessCoordProp.Value);
@@ -675,9 +674,11 @@ namespace Nova.Editor.Core.Scripts
             "Apply the vertex stream layout to all Particle Systems using this material");
 
         private readonly List<ParticleSystemRenderer> _renderersUsingThisMaterial = new List<ParticleSystemRenderer>();
-        private List<ParticleSystemVertexStream> _correctVertexStreams = new List<ParticleSystemVertexStream>();
 
-        private List<ParticleSystemVertexStream>
+        private readonly List<ParticleSystemVertexStream>
+            _correctVertexStreams = new List<ParticleSystemVertexStream>();
+
+        private readonly List<ParticleSystemVertexStream>
             _correctVertexStreamsInstanced = new List<ParticleSystemVertexStream>();
 
         # endregion

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
@@ -30,6 +30,8 @@ namespace Nova.Editor.Core.Scripts
             TransparencyFoldout = new BoolEditorPrefsProperty(transparencyFoldoutKey, true);
             AlphaTransitionFoldout = new BoolEditorPrefsProperty(alphaTransitionFoldoutKey, true);
             EmissionFoldout = new BoolEditorPrefsProperty(emissionFoldoutKey, true);
+
+            Setup(properties);
         }
 
         public void Setup(MaterialProperty[] properties)

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberLitGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberLitGUI.cs
@@ -6,7 +6,6 @@ using System;
 using Nova.Editor.Foundation.Scripts;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Rendering;
 using PropertyNames = Nova.Editor.Core.Scripts.MaterialPropertyNames;
 
 namespace Nova.Editor.Core.Scripts
@@ -16,8 +15,7 @@ namespace Nova.Editor.Core.Scripts
     /// </summary>
     internal sealed class ParticlesUberLitGUI : ParticlesGUI
     {
-        private readonly ParticlesUberCommonGUI _commonGUI = new ParticlesUberCommonGUI();
-
+        private ParticlesUberCommonGUI _commonGUI;
         private ParticlesUberCommonMaterialProperties _commonMaterialProperties;
         private MaterialEditor _editor;
 
@@ -56,9 +54,8 @@ namespace Nova.Editor.Core.Scripts
 
         protected override void Initialize(MaterialEditor editor, MaterialProperty[] properties)
         {
-            // common properties
+            _commonGUI = new ParticlesUberCommonGUI(editor);
             _commonMaterialProperties = new ParticlesUberCommonMaterialProperties(editor, properties);
-
             // Lit Settings
             var prefsKeyPrefix = $"{GetType().Namespace}.{GetType().Name}.";
             var litSettingsFoldoutKey = $"{prefsKeyPrefix}{nameof(LitSettingsFoldout)}";
@@ -92,6 +89,8 @@ namespace Nova.Editor.Core.Scripts
             _commonGUI.DrawEmissionProperties();
             // Transparency
             _commonGUI.DrawTransparencyProperties();
+            // FixNow
+            _commonGUI.DrawFixNowButton();
         }
 
         private void InternalDrawSurfaceMapsTexturePropertiesCore(string label, Property map2DProp,
@@ -218,7 +217,7 @@ namespace Nova.Editor.Core.Scripts
         private readonly Property _specularMap2DArrayProp = new Property(PropertyNames.SpecularMap2DArray);
         private readonly Property _specularMap3DProp = new Property(PropertyNames.SpecularMap3D);
         private readonly Property _specularProp = new Property(PropertyNames.Specular);
-        
+
         // metallicMap
         private readonly Property _metallicMapProp = new Property(PropertyNames.MetallicMap);
         private readonly Property _metallicMap2DArrayProp = new Property(PropertyNames.MetallicMap2DArray);

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberLitMaterialPostProcessor.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberLitMaterialPostProcessor.cs
@@ -2,7 +2,6 @@
 // Copyright 2022 CyberAgent, Inc.
 // --------------------------------------------------------------
 
-using System;
 using UnityEngine;
 
 namespace Nova.Editor.Core.Scripts
@@ -19,45 +18,53 @@ namespace Nova.Editor.Core.Scripts
             Shader.PropertyToID(MaterialPropertyNames.SpecularHighlights);
 
         private static readonly int NormalMapId = Shader.PropertyToID(MaterialPropertyNames.NormalMap);
-        private static readonly int NormalMap2DArrayId =Shader.PropertyToID(MaterialPropertyNames.NormalMap2DArray); 
+        private static readonly int NormalMap2DArrayId = Shader.PropertyToID(MaterialPropertyNames.NormalMap2DArray);
         private static readonly int NormalMap3DId = Shader.PropertyToID(MaterialPropertyNames.NormalMap3D);
         private static readonly int MetallicMapId = Shader.PropertyToID(MaterialPropertyNames.MetallicMap);
-        private static readonly int MetallicMap2DArrayId = Shader.PropertyToID(MaterialPropertyNames.MetallicMap2DArray);
+
+        private static readonly int MetallicMap2DArrayId =
+            Shader.PropertyToID(MaterialPropertyNames.MetallicMap2DArray);
+
         private static readonly int MetallicMap3DId = Shader.PropertyToID(MaterialPropertyNames.MetallicMap3D);
         private static readonly int SmoothnessMapId = Shader.PropertyToID(MaterialPropertyNames.SmoothnessMap);
-        private static readonly int SmoothnessMap2DArrayId = Shader.PropertyToID(MaterialPropertyNames.SmoothnessMap2DArray);
+
+        private static readonly int SmoothnessMap2DArrayId =
+            Shader.PropertyToID(MaterialPropertyNames.SmoothnessMap2DArray);
+
         private static readonly int SmoothnessMap3DId = Shader.PropertyToID(MaterialPropertyNames.SmoothnessMap3D);
         private static readonly int SpecularMapId = Shader.PropertyToID(MaterialPropertyNames.SpecularMap);
-        private static readonly int SpecularMap2DArrayId = Shader.PropertyToID(MaterialPropertyNames.SpecularMap2DArray);
+
+        private static readonly int SpecularMap2DArrayId =
+            Shader.PropertyToID(MaterialPropertyNames.SpecularMap2DArray);
+
         private static readonly int SpecularMap3DId = Shader.PropertyToID(MaterialPropertyNames.SpecularMap3D);
         private static readonly int BaseMapModeId = Shader.PropertyToID(MaterialPropertyNames.BaseMapMode);
-        
+
         private static readonly int EnvironmentReflectionsEnabledId =
             Shader.PropertyToID(MaterialPropertyNames.EnvironmentReflections);
 
         private static readonly int WorkflowModeId = Shader.PropertyToID(MaterialPropertyNames.LitWorkflowMode);
 
-        private static bool HasSurfaceMap(Material material, BaseMapMode baseMapMode, int map2DId, int map2DArrayId, int map3DID)
+        private static bool HasSurfaceMap(Material material, BaseMapMode baseMapMode, int map2DId, int map2DArrayId,
+            int map3DID)
         {
             switch (baseMapMode)
             {
                 case BaseMapMode.SingleTexture:
                     return material.GetTexture(map2DId) != null;
-                    break;
                 case BaseMapMode.FlipBook:
                     return material.GetTexture(map2DArrayId) != null;
-                    break;
                 case BaseMapMode.FlipBookBlending:
                     return material.GetTexture(map3DID) != null;
-                    break;
             }
 
             return false;
         }
+
         public static void SetupMaterialKeywords(Material material)
         {
             ParticlesUberUnlitMaterialPostProcessor.SetupMaterialKeywords(material);
-            
+
             var receiveShadowsEnabled = material.GetFloat(ReceiveShadowsEnabledId) > 0.5f;
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.ReceiveShadowsEnabled, receiveShadowsEnabled);
 
@@ -71,18 +78,21 @@ namespace Nova.Editor.Core.Scripts
 
             var specularSetup = (LitWorkflowMode)material.GetFloat(WorkflowModeId) == LitWorkflowMode.Specular;
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.SpecularSetup, specularSetup);
-            
+
             var baseMapMode = (BaseMapMode)material.GetFloat(BaseMapModeId);
             var hasNormalMap = HasSurfaceMap(material, baseMapMode, NormalMapId, NormalMap2DArrayId, NormalMap3DId);
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.NormalMapEnabled, hasNormalMap);
 
-            var hasMetallicMap = HasSurfaceMap(material, baseMapMode, MetallicMapId, MetallicMap2DArrayId, MetallicMap3DId);
+            var hasMetallicMap =
+                HasSurfaceMap(material, baseMapMode, MetallicMapId, MetallicMap2DArrayId, MetallicMap3DId);
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.MetallicMapEnabled, hasMetallicMap);
 
-            var hasSmoothnessMap = HasSurfaceMap(material, baseMapMode, SmoothnessMapId, SmoothnessMap2DArrayId, SmoothnessMap3DId);
+            var hasSmoothnessMap = HasSurfaceMap(material, baseMapMode, SmoothnessMapId, SmoothnessMap2DArrayId,
+                SmoothnessMap3DId);
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.SmoothnessMapEnabled, hasSmoothnessMap);
 
-            var hasSpecularMap = HasSurfaceMap(material, baseMapMode, SpecularMapId, SpecularMap2DArrayId, SpecularMap3DId);
+            var hasSpecularMap =
+                HasSurfaceMap(material, baseMapMode, SpecularMapId, SpecularMap2DArrayId, SpecularMap3DId);
             MaterialEditorUtility.SetKeyword(material, ShaderKeywords.SpecularMapEnabled, hasSpecularMap);
         }
 

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberUnlitGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberUnlitGUI.cs
@@ -13,7 +13,7 @@ namespace Nova.Editor.Core.Scripts
     /// </summary>
     internal sealed class ParticlesUberUnlitGUI : ParticlesGUI
     {
-        private readonly ParticlesUberCommonGUI _commonGUI = new ParticlesUberCommonGUI();
+        private ParticlesUberCommonGUI _commonGUI;
 
         private ParticlesUberCommonMaterialProperties _commonMaterialProperties;
 
@@ -24,6 +24,7 @@ namespace Nova.Editor.Core.Scripts
 
         protected override void Initialize(MaterialEditor editor, MaterialProperty[] properties)
         {
+            _commonGUI = new ParticlesUberCommonGUI(editor);
             _commonMaterialProperties = new ParticlesUberCommonMaterialProperties(editor, properties);
         }
 
@@ -38,6 +39,7 @@ namespace Nova.Editor.Core.Scripts
             _commonGUI.DrawAlphaTransitionProperties();
             _commonGUI.DrawEmissionProperties();
             _commonGUI.DrawTransparencyProperties();
+            _commonGUI.DrawFixNowButton();
         }
 
         protected override void MaterialChanged(Material material)


### PR DESCRIPTION
シェーダーが求めている入力アトリビュートと、パーティクルシステムに設定されている入力アトリビュートの差異をボタン入力一発で修正する機能を実装しました。

頂点シェーダーへの入力アトリビュートは下記の３つのケースで変化します。

・カスタームコードの有無
・GPUインスタンスの有効/無効
・法線マップの有無

これらすべてのケースで修正のためのボタンが表示

され、正しくアトリビュートが修正されていることを確認しました。
動作テストを行った動画を添付していますので、ご確認ください。

https://user-images.githubusercontent.com/106138524/188345688-d1786bc8-1f88-4e8a-803e-9b89cd0d64b5.mp4
カスタムコード( 0:00:00～ )
GPUインスタンシング( 0:01:08～ )
法線マップ ( 0:01:37～ )　　　　


あと、 a2aa4da8997daf36d28b1e78c081cde3172fac85 のコミットで、テストを行っている際にTint ColorのModeにRimを設定している際にProgressとShapenessのカスタムコードが正しく設定できていないUI側の具合があったので修正しています。
(  ProgressがShapenessのカスタムコードの設定を使って表示されていた )