### PR TITLE
Fix the issue where artifacts occur due to texture compression errors in emission.

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
@@ -489,7 +489,7 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
                                half emissionChannelsX)
 {
     // Texture compression may introduce an error of 1/256, so it's advisable to allow for some margin
-    #define TEX_COMP_ERR_MARGIN 0.004
+    const half tex_comp_err_margin = 0.004;
     
     half emissionIntensity = 0;
     half emissionColorRampU = 0;
@@ -501,13 +501,13 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
     #if defined(_EMISSION_COLOR_COLOR) || defined(_EMISSION_COLOR_BASECOLOR)
     emissionIntensity = emissionMapValue;
     #elif _EMISSION_COLOR_MAP
-    emissionIntensity = step(TEX_COMP_ERR_MARGIN, emissionMapValue);
+    emissionIntensity = step(tex_comp_err_margin, emissionMapValue);
     emissionColorRampU = emissionMapValue;
     #endif
     #elif _EMISSION_AREA_ALPHA
-    emissionIntensity = step(TEX_COMP_ERR_MARGIN, 1.0 - color.a);
+    emissionIntensity = step(tex_comp_err_margin, 1.0 - color.a);
     emissionColorRampU = color.a;
-    color.a = _KeepEdgeTransparency >= 0.5f ? color.a : step(TEX_COMP_ERR_MARGIN, color.a);
+    color.a = _KeepEdgeTransparency >= 0.5f ? color.a : step(tex_comp_err_margin, color.a);
     #endif
 
     half3 emissionColor = 0;
@@ -521,8 +521,6 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
 
     emissionIntensity *= intensity;
     color.rgb += emissionColor * emissionIntensity;
-    
-    #undef TEX_COMP_ERR_MARGIN
 }
 
 // Returns the value defined by rim.

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
@@ -488,6 +488,9 @@ inline void ApplyVertexColor(in out half4 color, in half4 vertexColor)
 inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float intensity, half emissionMapProgress,
                                half emissionChannelsX)
 {
+    // Texture compression may introduce an error of 1/256, so it's advisable to allow for some margin
+    #define TEX_COMP_ERR_MARGIN 0.004
+    
     half emissionIntensity = 0;
     half emissionColorRampU = 0;
     #ifdef _EMISSION_AREA_ALL
@@ -498,13 +501,13 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
     #if defined(_EMISSION_COLOR_COLOR) || defined(_EMISSION_COLOR_BASECOLOR)
     emissionIntensity = emissionMapValue;
     #elif _EMISSION_COLOR_MAP
-    emissionIntensity = step(0.0001, emissionMapValue);
+    emissionIntensity = step(TEX_COMP_ERR_MARGIN, emissionMapValue);
     emissionColorRampU = emissionMapValue;
     #endif
     #elif _EMISSION_AREA_ALPHA
-    emissionIntensity = step(0.0001, 1.0 - color.a);
+    emissionIntensity = step(TEX_COMP_ERR_MARGIN, 1.0 - color.a);
     emissionColorRampU = color.a;
-    color.a = _KeepEdgeTransparency >= 0.5f ? color.a : step(0.0001, color.a);
+    color.a = _KeepEdgeTransparency >= 0.5f ? color.a : step(TEX_COMP_ERR_MARGIN, color.a);
     #endif
 
     half3 emissionColor = 0;
@@ -518,6 +521,8 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
 
     emissionIntensity *= intensity;
     color.rgb += emissionColor * emissionIntensity;
+    
+    #undef TEX_COMP_ERR_MARGIN
 }
 
 // Returns the value defined by rim.


### PR DESCRIPTION
We have fixed an issue where setting the base map texture compression to High Quality would apply BC7, but unintended judgments due to errors could occur, resulting in artifacts.

---

ベースマップテクスチャの圧縮設定をHigh Qualityに指定した場合にBC7が適用されますが、誤差により意図しない判定が行われアーティファクトが発生する問題を修正しました。

<img width="547" alt="image" src="https://github.com/CyberAgentGameEntertainment/NovaShader/assets/149571050/a024291d-a0c4-4fd6-8213-28fc7a65d490">
