### PR TITLE
Added note regarding PreviewRenderUtility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1427,6 +1427,9 @@ The texture will now rotate.
 You can use the [Particle System Mesh GPU Instancing](https://docs.unity3d.com/Manual/PartSysInstancing.html) to draw particles efficiently.
 The following section describes how to use `Mesh GPU Instancing` for materials using this shader.
 
+> **Note**  
+> When displaying particles on the preview screen using **PreviewRenderUtility**, we have confirmed a bug on the Unity side that does not render correctly when **Enable Mesh GPU Instancing** is enabled.
+
 #### Enable Mesh GPU Instancing
 To use `Mesh GPU Instancing`, you need to set the `Render Mode` of the `Renderer` module to Mesh.
 Then, check the `Enable Mesh GPU Instancing` checkbox.

--- a/README_JA.md
+++ b/README_JA.md
@@ -1435,6 +1435,8 @@ Particle SystemのCustom Vertex Streamsを使うと、マテリアルのプロ�
 ## Mesh GPU Instancingを使う
 [Particle System Mesh GPU Instancing](https://docs.unity3d.com/Manual/PartSysInstancing.html)を使うと、パーティクルを効率的に描画できます。  
 以下では本シェーダを使ったマテリアルに対して`Mesh GPU Instancing`を有効化する手順について説明します。
+> **Note**  
+> **PreviewRenderUtility**を利用したプレビュー画面上でパーティクルを表示する場合、**Enable Mesh GPU Instancing**が有効に設定されていると正常に描画されないUnity側の不具合を確認しています。
 
 #### Mesh GPU Instancingを有効化する
 `Mesh GPU Instancing`を使うには`Renderer`モジュールの`Render Mode`をMeshにする必要があります。  


### PR DESCRIPTION
Added a note that particles on the preview screen using PreviewRenderUtility will not render correctly if Enable Mesh GPU Instancing is enabled.

---

PreviewRenderUtilityを利用したプレビュー画面上でパーティクルを表示する場合、Enable Mesh GPU Instancingが有効に設定されていると正常に描画されない旨の追記。