### PR TITLE
TintColorMapのOffsetにCustomCoord追加

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/MaterialPropertyNames.cs
+++ b/Assets/Nova/Editor/Core/Scripts/MaterialPropertyNames.cs
@@ -70,6 +70,8 @@ namespace Nova.Editor.Core.Scripts
         public const string TintMap3DProgress = "_TintMap3DProgress";
         public const string TintMap3DProgressCoord = "_TintMap3DProgressCoord";
         public const string TintMapSliceCount = "_TintMapSliceCount";
+        public const string TintMapOffsetXCoord = "_TintMapOffsetXCoord";
+        public const string TintMapOffsetYCoord = "_TintMapOffsetYCoord";
         public const string TintMapBlendRate = "_TintBlendRate";
         public const string TintMapBlendRateCoord = "_TintBlendRateCoord";
         public const string TintRimProgress = "_TintRimProgress";
@@ -87,7 +89,7 @@ namespace Nova.Editor.Core.Scripts
         public const string FlowIntensity = "_FlowIntensity";
         public const string FlowIntensityCoord = "_FlowIntensityCoord";
         public const string FlowMapTarget = "_FlowMapTarget";
-        
+
         // Parallax Map
         public const string ParallaxMapMode = "_ParallaxMapMode";
         public const string ParallaxMap = "_ParallaxMap";
@@ -164,7 +166,7 @@ namespace Nova.Editor.Core.Scripts
         // Distortion
         public const string DistortionIntensity = "_DistortionIntensity";
         public const string DistortionIntensityCoord = "_DistortionIntensityCoord";
-        
+
         // Vertex Deformation
         public const string VertexDeformationMap = "_VertexDeformationMap";
         public const string VertexDeformationMapOffsetXCoord = "_VertexDeformationMapOffsetXCoord";
@@ -172,7 +174,7 @@ namespace Nova.Editor.Core.Scripts
         public const string VertexDeformationMapChannel = "_VertexDeformationMapChannel";
         public const string VertexDeformationIntensity = "_VertexDeformationIntensity";
         public const string VertexDeformationIntensityCoord = "_VertexDeformationIntensityCoord";
-        
+
         // Shadow Caster
         public const string ShadowCasterEnabled = "_ShadowCasterEnabled";
         public const string ShadowCasterApplyVertexDeformation = "_ShadowCasterApplyVertexDeformation";

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
@@ -314,13 +314,17 @@ namespace Nova.Editor.Core.Scripts
             }
             else if (tintColorMode == TintColorMode.Texture2D)
             {
-                MaterialEditorUtility.DrawTexture(_editor, props.TintMapProp.Value, true);
+                MaterialEditorUtility.DrawTexture(_editor, props.TintMapProp.Value,
+                    props.TintMapOffsetXCoordProp.Value, props.TintMapOffsetYCoordProp.Value,
+                    null, null);
             }
             else if (tintColorMode == TintColorMode.Texture3D)
             {
                 using (var changeCheckScope = new EditorGUI.ChangeCheckScope())
                 {
-                    MaterialEditorUtility.DrawTexture(_editor, props.TintMap3DProp.Value, true);
+                    MaterialEditorUtility.DrawTexture(_editor, props.TintMap3DProp.Value,
+                        props.TintMapOffsetXCoordProp.Value, props.TintMapOffsetYCoordProp.Value,
+                        null, null);
 
                     if (changeCheckScope.changed && props.TintMap3DProp.Value.textureValue != null)
                     {
@@ -587,24 +591,24 @@ namespace Nova.Editor.Core.Scripts
                 props.VertexDeformationIntensityProp.Value,
                 props.VertexDeformationIntensityCoordProp.Value);
         }
-        
+
         private void InternalDrawShadowCasterProperties()
         {
             var props = _commonMaterialProperties;
             MaterialEditorUtility.DrawToggleProperty(_editor, "Enable", props.ShadowCasterEnabledProp.Value);
-            if (props.ShadowCasterEnabledProp.Value.floatValue < 0.5f) 
+            if (props.ShadowCasterEnabledProp.Value.floatValue < 0.5f)
                 return;
-            
+
             MaterialEditorUtility.DrawToggleProperty(_editor, "Apply Vertex Deformation", props.ShadowCasterApplyVertexDeformationProp.Value);
-            
+
             MaterialEditorUtility.DrawToggleProperty(_editor, "Alpha Test Enable", props.ShadowCasterAlphaTestEnabledProp.Value);
             if (props.ShadowCasterAlphaTestEnabledProp.Value.floatValue < 0.5f)
                 return;
-            
+
             EditorGUI.indentLevel++;
             MaterialEditorUtility.DrawFloatRangeProperty(_editor, "Cutoff", props.ShadowCasterAlphaCutoffProp.Value, 0, 1);
             EditorGUI.indentLevel--;
-            
+
             EditorGUI.LabelField(EditorGUILayout.GetControlRect(), "Alpha Affected By");
             EditorGUI.indentLevel++;
             MaterialEditorUtility.DrawToggleProperty(_editor, "Tint Color", props.ShadowCasterAlphaAffectedByTintColorProp.Value);

--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
@@ -79,6 +79,8 @@ namespace Nova.Editor.Core.Scripts
             TintMap3DProgressProp.Setup(properties);
             TintMap3DProgressCoordProp.Setup(properties);
             TintMapSliceCountProp.Setup(properties);
+            TintMapOffsetXCoordProp.Setup(properties);
+            TintMapOffsetYCoordProp.Setup(properties);
             TintMapBlendRateProp.Setup(properties);
             TintMapBlendRateCoordProp.Setup(properties);
             TintRimProgressProp.Setup(properties);
@@ -177,7 +179,7 @@ namespace Nova.Editor.Core.Scripts
             VertexDeformationMapChannelProp.Setup(properties);
             VertexDeformationIntensityProp.Setup(properties);
             VertexDeformationIntensityCoordProp.Setup(properties);
-            
+
             // Shadow Caster
             ShadowCasterEnabledProp.Setup(properties);
             ShadowCasterApplyVertexDeformationProp.Setup(properties);
@@ -272,6 +274,10 @@ namespace Nova.Editor.Core.Scripts
         public ParticlesGUI.Property TintMap3DProgressCoordProp { get; } = new(PropertyNames.TintMap3DProgressCoord);
 
         public ParticlesGUI.Property TintMapSliceCountProp { get; } = new(PropertyNames.TintMapSliceCount);
+
+        public ParticlesGUI.Property TintMapOffsetXCoordProp { get; } = new(PropertyNames.TintMapOffsetXCoord);
+
+        public ParticlesGUI.Property TintMapOffsetYCoordProp { get; } = new(PropertyNames.TintMapOffsetYCoord);
 
         public ParticlesGUI.Property TintMapBlendRateProp { get; } = new(PropertyNames.TintMapBlendRate);
 
@@ -488,7 +494,7 @@ namespace Nova.Editor.Core.Scripts
         #endregion
 
         #region Shadow Caster Material Properties
-        
+
         public ParticlesGUI.Property ShadowCasterEnabledProp { get; } = new(PropertyNames.ShadowCasterEnabled);
         public ParticlesGUI.Property ShadowCasterApplyVertexDeformationProp { get; } = new(PropertyNames.ShadowCasterApplyVertexDeformation);
         public ParticlesGUI.Property ShadowCasterAlphaTestEnabledProp { get; } = new(PropertyNames.ShadowCasterAlphaTestEnabled);
@@ -497,7 +503,7 @@ namespace Nova.Editor.Core.Scripts
         public ParticlesGUI.Property ShadowCasterAlphaAffectedByFlowMapProp { get; } = new(PropertyNames.ShadowCasterAlphaAffectedByFlowMap);
         public ParticlesGUI.Property ShadowCasterAlphaAffectedByAlphaTransitionMapProp { get; } = new(PropertyNames.ShadowCasterAlphaAffectedByAlphaTransitionMap);
         public ParticlesGUI.Property ShadowCasterAlphaAffectedByTransparencyLuminanceProp { get; } = new(PropertyNames.ShadowCasterAlphaAffectedByTransparencyLuminance);
-        
+
         #endregion
     }
 }

--- a/Assets/Nova/Editor/Core/Scripts/RendererErrorHandler.cs
+++ b/Assets/Nova/Editor/Core/Scripts/RendererErrorHandler.cs
@@ -37,7 +37,7 @@ namespace Nova.Editor.Core.Scripts
 
             return CheckError(renderersWithMaterial, correctVertexStreams, correctVertexStreamsInstanced);
         }
-        
+
         /// <summary>
         ///     Corrects errors in renderers using the specified material.
         /// </summary>
@@ -106,8 +106,14 @@ namespace Nova.Editor.Core.Scripts
                                          || IsCustomCoordUsed(commonMaterialProperties.TintRimSharpnessCoordProp);
 
                 var tintMapMode = (TintColorMode)commonMaterialProperties.TintColorModeProp.Value.floatValue;
-                if (tintMapMode == TintColorMode.Texture3D)
-                    isCustomCoordUsed |= IsCustomCoordUsed(commonMaterialProperties.TintMap3DProgressCoordProp);
+                if (tintMapMode == TintColorMode.Texture2D || tintMapMode == TintColorMode.Texture3D)
+                {
+                    isCustomCoordUsed |= IsCustomCoordUsed(commonMaterialProperties.TintMapOffsetXCoordProp)
+                                         || IsCustomCoordUsed(commonMaterialProperties.TintMapOffsetYCoordProp);
+
+                    if (tintMapMode == TintColorMode.Texture3D)
+                        isCustomCoordUsed |= IsCustomCoordUsed(commonMaterialProperties.TintMap3DProgressCoordProp);
+                }
             }
 
             return isCustomCoordUsed;

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
@@ -88,6 +88,8 @@ float4 _TintMap3D_ST;
 float _TintMap3DProgress;
 DECLARE_CUSTOM_COORD(_TintMap3DProgressCoord);
 float _TintMapSliceCount;
+DECLARE_CUSTOM_COORD(_TintMapOffsetXCoord);
+DECLARE_CUSTOM_COORD(_TintMapOffsetYCoord);
 float _TintBlendRate;
 float _TintBlendRateCoord;
 float _TintRimProgress;
@@ -490,7 +492,7 @@ inline void ApplyEmissionColor(in out half4 color, half2 emissionMapUv, float in
 {
     // Texture compression may introduce an error of 1/256, so it's advisable to allow for some margin
     const half tex_comp_err_margin = 0.004;
-    
+
     half emissionIntensity = 0;
     half emissionColorRampU = 0;
     #ifdef _EMISSION_AREA_ALL
@@ -625,7 +627,7 @@ inline half2 GetParallaxMappingUVOffset(in half2 uv, in half progress, in half c
 {
     half4 map = SAMPLE_PARALLAX_MAP(uv, progress);
     half height = map[(int)channel];
-    half2 offset = ParallaxOffset(height, scale, viewDirTS);    
+    half2 offset = ParallaxOffset(height, scale, viewDirTS);
     return offset;
 }
 #endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
@@ -5,8 +5,8 @@
 #define NOVA_PARTICLESUBERDEPTHNORMALSCORE_INCLUDED
 
 
-// If defined _ALPHATEST_ENABLED or  _NORMAL_MAP_ENABLED, base map uv is enabled. 
-#if defined( _ALPHATEST_ENABLED ) || defined(_NORMAL_MAP_ENABLED) 
+// If defined _ALPHATEST_ENABLED or  _NORMAL_MAP_ENABLED, base map uv is enabled.
+#if defined( _ALPHATEST_ENABLED ) || defined(_NORMAL_MAP_ENABLED)
 #define _USE_BASE_MAP_UV
 #endif
 
@@ -29,7 +29,7 @@
     #endif
 #endif
 
-#if defined( _ALPHATEST_ENABLED ) || defined(_USE_FLOW_MAP) || defined(_USE_BASE_MAP_UV) 
+#if defined( _ALPHATEST_ENABLED ) || defined(_USE_FLOW_MAP) || defined(_USE_BASE_MAP_UV)
 #define _USE_CUSTOM_COORD
 #endif
 
@@ -60,7 +60,7 @@ struct AttributesDrawDepth
     #endif
     #ifdef _ALPHATEST_ENABLED // This attributes is not used for opaque objects.
     float4 color : COLOR;
-    
+
     #endif
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
@@ -79,7 +79,7 @@ struct VaryingsDrawDepth
     float3 binormalWS : BINORMAL;
     #endif
     #endif
-    
+
     #ifdef _USE_CUSTOM_COORD
     INPUT_CUSTOM_COORD(0, 1)
     #endif
@@ -90,7 +90,7 @@ struct VaryingsDrawDepth
     #if defined( _USE_FLOW_MAP ) || defined(_USE_TRANSITION_MAP)
     float4 flowTransitionUVs : TEXCOORD3; // xy: FlowMap UV, zw: TransitionMap UV
     #endif
-    
+
     #ifdef _ALPHATEST_ENABLED // This attributes is not used for opaque objects.
     float4 color : COLOR;
     float4 tintEmissionUV : TEXCOORD4; // xy: TintMap UV, zw: EmissionMap UV
@@ -99,7 +99,7 @@ struct VaryingsDrawDepth
     #ifdef FRAGMENT_USE_VIEW_DIR_WS
     float3 viewDirWS : TEXCOORD6;
     #endif
-    
+
     #ifdef USE_PROJECTED_POSITION
     float4 projectedPosition : TEXCOORD7;
     #endif
@@ -110,7 +110,7 @@ struct VaryingsDrawDepth
 /**
  * \brief Initialize output data from vertex shader for DepthOnly and DepthNormals pass.
  * \param[in] input Input attributes to vertex shader.
- * \param[in,out] output Output data from vertex shader. 
+ * \param[in,out] output Output data from vertex shader.
  */
 inline void InitializeVertexOutputDrawDepth(in AttributesDrawDepth input, in out VaryingsDrawDepth output)
 {
@@ -129,7 +129,7 @@ inline void InitializeVertexOutputDrawDepth(in AttributesDrawDepth input, in out
     float3 positionWS = TransformObjectToWorld(input.positionOS.xyz);
     output.viewDirWS = GetWorldSpaceViewDir(positionWS);
     #endif
-    
+
     #ifdef USE_PROJECTED_POSITION
     output.projectedPosition = ComputeScreenPos(output.positionHCS);
     #endif
@@ -147,7 +147,7 @@ inline void InitializeFragmentInputDrawDepth(in out VaryingsDrawDepth input)
     #endif
 
     #ifdef _ALPHATEST_ENABLED // This code is not used for opaque objects.
-    #ifdef FRAGMENT_USE_VIEW_DIR_WS 
+    #ifdef FRAGMENT_USE_VIEW_DIR_WS
     input.viewDirWS = normalize(input.viewDirWS);
     #endif
     #endif
@@ -156,7 +156,7 @@ inline void InitializeFragmentInputDrawDepth(in out VaryingsDrawDepth input)
 /**
  * \brief Vertex shader entry point.
  * \param input Input attribute.
- * \return Return data of VaryingsDrawDepth Structure. 
+ * \return Return data of VaryingsDrawDepth Structure.
  */
 VaryingsDrawDepth vert(AttributesDrawDepth input)
 {
@@ -169,7 +169,7 @@ VaryingsDrawDepth vert(AttributesDrawDepth input)
     TRANSFER_CUSTOM_COORD(input, output);
     #endif
     InitializeVertexOutputDrawDepth(input, output);
-    
+
     #ifdef _USE_BASE_MAP_UV
     // Base Map UV
     float2 baseMapUv = input.texcoord.xy;
@@ -197,7 +197,7 @@ VaryingsDrawDepth vert(AttributesDrawDepth input)
     output.flowTransitionUVs.w += GET_CUSTOM_COORD(_AlphaTransitionMapOffsetYCoord)
     #endif
     #ifdef _ALPHATEST_ENABLED // This code is not used for opaque objects.
-    
+
     // Base Map Progress
     #ifdef _BASE_MAP_MODE_2D_ARRAY
     float baseMapProgress = _BaseMapProgress + GET_CUSTOM_COORD(_BaseMapProgressCoord);
@@ -210,6 +210,8 @@ VaryingsDrawDepth vert(AttributesDrawDepth input)
     // Tint Map UV
     #if defined(_TINT_MAP_ENABLED) || defined(_TINT_MAP_3D_ENABLED)
     output.tintEmissionUV.xy = TRANSFORM_TINT_MAP(input.texcoord.xy);
+    output.tintEmissionUV.x += GET_CUSTOM_COORD(_TintMapOffsetXCoord);
+    output.tintEmissionUV.y += GET_CUSTOM_COORD(_TintMapOffsetYCoord);
     #endif
 
     // Tint Map Progress
@@ -247,7 +249,7 @@ VaryingsDrawDepth vert(AttributesDrawDepth input)
     //Fog
     // output.transitionEmissionProgresses.z = ComputeFogFactor(output.positionHCS.z);
     #endif
-    
+
     return output;
 }
 
@@ -261,18 +263,18 @@ half4 frag(VaryingsDrawDepth input) : SV_Target
 {
     UNITY_SETUP_INSTANCE_ID(input);
     SETUP_FRAGMENT;
-    
+
     #ifdef _USE_CUSTOM_COORD
     SETUP_CUSTOM_COORD(input);
     #endif
-    
+
     InitializeFragmentInputDrawDepth(input);
 
     #if defined(_TRANSPARENCY_BY_RIM) || defined(_TINT_AREA_RIM)
     half rim = 1.0 - abs(dot(input.normalWS, input.viewDirWS));
     #endif
-    
-    // Flow map 
+
+    // Flow map
     #if defined( _USE_FLOW_MAP)
     half intensity = _FlowIntensity + GET_CUSTOM_COORD(_FlowIntensityCoord);
     half2 flowMapUvOffset = GetFlowMapUvOffset(_FlowMap, sampler_FlowMap, intensity, input.flowTransitionUVs.xy, _FlowMapChannelsX, _FlowMapChannelsY);
@@ -289,11 +291,11 @@ half4 frag(VaryingsDrawDepth input) : SV_Target
         input.flowTransitionUVs.zw += flowMapUvOffset;
     #endif
     #endif
-    
+
     #ifdef _ALPHATEST_ENABLED // This code is not used for opaque objects.
     // Base Color
     half4 color = SAMPLE_BASE_MAP(input.baseMapUVAndProgresses.xy, input.baseMapUVAndProgresses.z);
-    
+
     // Tint Color
     #if defined(_TINT_AREA_ALL) || defined(_TINT_AREA_RIM)
     half tintBlendRate = _TintBlendRate + GET_CUSTOM_COORD(_TintBlendRateCoord);
@@ -312,7 +314,7 @@ half4 frag(VaryingsDrawDepth input) : SV_Target
     ModulateAlphaTransitionProgress(alphaTransitionProgress, input.color.a);
     color.a *= GetTransitionAlpha(alphaTransitionProgress, input.flowTransitionUVs.zw, input.transitionEmissionProgresses.x, _AlphaTransitionMapChannelsX);
     #endif
-    
+
     // NOTE : Not need in DepthNormals pass.
     // Color Correction
     // ApplyColorCorrection(color.rgb);
@@ -354,7 +356,7 @@ half4 frag(VaryingsDrawDepth input) : SV_Target
     #endif
 
     AlphaClip(color.a, _Cutoff);
-    
+
     // NOTE : Not need in DepthNormals pass.
     // color.rgb = ApplyAlpha(color.rgb, color.a);
     #endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
@@ -64,6 +64,8 @@ Shader "Nova/Particles/UberLit"
         _TintMap3DProgress("Tint Map 3D Progress", Range(0, 1)) = 0.0
         _TintMap3DProgressCoord("Tint Map 3D Progress Coord", Float) = 0.0
         _TintMapSliceCount("Base Map Slice Count", Float) = 4.0
+        _TintMapOffsetXCoord("Tint Map Offset X Coord", Float) = 0.0
+        _TintMapOffsetYCoord("Tint Map Offset Y Coord", Float) = 0.0
         _TintBlendRate("Tint Blend Rate", Range(0.0, 1.0)) = 1.0
         _TintBlendRateCoord("Tint Blend Rate Coord", Float) = 0.0
         _TintRimProgress("Tint Rim Progress", Range(0.0, 1.0)) = 0.5
@@ -81,7 +83,7 @@ Shader "Nova/Particles/UberLit"
         _FlowIntensity("Flow Intensity", Float) = 1.0
         _FlowIntensityCoord("Flow Intensity Coord", Float) = 0.0
         _FlowMapTarget("Flow Map Target", Float) = 1.0
-        
+
         // Parallax Map
         _ParallaxMapMode("Emission Map Mode", Float) = 0.0
         _ParallaxMap("Parallax Map", 2D) = "" {}
@@ -154,7 +156,7 @@ Shader "Nova/Particles/UberLit"
         _DepthFadeNear("Depth Fade Near", Float) = 1.0
         _DepthFadeFar("Depth Fade Far", Float) = 10.0
         _DepthFadeWidth("Depth Fade Width", Float) = 1.0
-        
+
         // Vertex Deformation
         _VertexDeformationEnabled ("Vertex Deformation Enabled", Float) = 0
         _VertexDeformationMap ("Vertex Deformation Map", 2D) = "white" {}
@@ -163,7 +165,7 @@ Shader "Nova/Particles/UberLit"
         _VertexDeformationMapChannel("VertexDeformation Map Channel", Float) = 0.0
         _VertexDeformationIntensity("VertexDeformation Intensity", Float) = 0.1
         _VertexDeformationIntensityCoord("VertexDeformation Intensity Coord", Float) = 0.0
-        
+
         // Shadow Caster
         _ShadowCasterEnabled("Shadow Caster", Float) = 0
         _ShadowCasterApplyVertexDeformation("Shadow Caster Vertex Deformation Enabled", Float) = 0
@@ -218,12 +220,12 @@ Shader "Nova/Particles/UberLit"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
-            
+
             // Render Settings
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS
             #pragma shader_feature_local_fragment _ALPHAMODULATE_ENABLED
             #pragma shader_feature_local_fragment _ALPHATEST_ENABLED
-            
+
             #pragma shader_feature_local _RECEIVE_SHADOWS_ENABLED
             #pragma shader_feature_local _SPECULAR_HIGHLIGHTS_ENABLED
             #pragma shader_feature_local _ENVIRONMENT_REFLECTIONS_ENABLED
@@ -256,7 +258,7 @@ Shader "Nova/Particles/UberLit"
             #pragma shader_feature_local _PARALLAX_MAP_TARGET_TINT
             #pragma shader_feature_local _PARALLAX_MAP_TARGET_EMISSION
             #pragma shader_feature_local _PARALLAX_MAP_MODE_2D _PARALLAX_MAP_MODE_2D_ARRAY _PARALLAX_MAP_MODE_3D
-            
+
             // Color Correction
             #pragma shader_feature_local_fragment _ _GREYSCALE_ENABLED _GRADIENT_MAP_ENABLED
 
@@ -353,7 +355,7 @@ Shader "Nova/Particles/UberLit"
 
             // Vertex Deformation
             #pragma shader_feature_local_vertex _ _VERTEX_DEFORMATION_ENABLED
-            
+
             // When LightMode is SceneSelectionPass, the shaders are the same as in the Unlit version,
             // so there is no problem.
             #include "ParticlesUberUnlitEditor.hlsl"
@@ -596,7 +598,7 @@ Shader "Nova/Particles/UberLit"
             #include "ParticlesUberDepthOnly.hlsl"
             ENDHLSL
         }
-        
+
         Pass
         {
             Name "ShadowCaster"

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberShadowCaster.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberShadowCaster.hlsl
@@ -87,7 +87,7 @@ Varyings ShadowPassVertex(Attributes input)
         input.positionOS.xyz += normalize(input.normalOS) * vertexDeformationIntensity;
     }
     #endif
-    
+
     output.positionHCS = GetShadowPositionHClip(input);
 
     #ifdef _SHADOW_CASTER_ALPHA_TEST_ENABLED
@@ -116,6 +116,8 @@ Varyings ShadowPassVertex(Attributes input)
     // Tint Map UV
     #if defined(_TINT_MAP_ENABLED) || defined(_TINT_MAP_3D_ENABLED)
     output.tintUV = TRANSFORM_TINT_MAP(input.texcoord.xy);
+    output.tintUV.x += GET_CUSTOM_COORD(_TintMapOffsetXCoord);
+    output.tintUV.y += GET_CUSTOM_COORD(_TintMapOffsetYCoord);
     #endif
 
     // Tint Map Progress
@@ -130,7 +132,7 @@ Varyings ShadowPassVertex(Attributes input)
     output.flowTransitionUVs.x += GET_CUSTOM_COORD(_FlowMapOffsetXCoord);
     output.flowTransitionUVs.y += GET_CUSTOM_COORD(_FlowMapOffsetYCoord);
     #endif
-    
+
     // Transition Map UV
     #if defined(_FADE_TRANSITION_ENABLED) || defined(_DISSOLVE_TRANSITION_ENABLED)
     output.flowTransitionUVs.zw = TRANSFORM_ALPHA_TRANSITION_MAP(input.texcoord.xy);
@@ -147,7 +149,7 @@ Varyings ShadowPassVertex(Attributes input)
     output.transitionProgress = FlipBookBlendingProgress(transitionMapProgress, _AlphaTransitionMapSliceCount);
     #endif
     #endif
-    
+
     return output;
 }
 
@@ -179,7 +181,7 @@ half4 ShadowPassFragment(Varyings input) : SV_TARGET
         #endif
     }
     #endif
-    
+
     // Base Color
     half4 color = SAMPLE_BASE_MAP(input.baseMapUVAndProgresses.xy, input.baseMapUVAndProgresses.z);
 
@@ -195,7 +197,7 @@ half4 ShadowPassFragment(Varyings input) : SV_TARGET
         #endif
     }
     #endif
-    
+
     // Alpha Transition
     #if defined(_FADE_TRANSITION_ENABLED) || defined(_DISSOLVE_TRANSITION_ENABLED)
     if (_ShadowCasterAlphaAffectedByAlphaTransitionMap)
@@ -218,10 +220,10 @@ half4 ShadowPassFragment(Varyings input) : SV_TARGET
         ApplyLuminanceTransparency(color, luminanceTransparencyProgress, luminanceTransparencySharpness);
     }
     #endif
-    
+
     clip(color.a - _ShadowCasterAlphaCutoff);
     #endif
-    
+
     return 0;
 }
 

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
@@ -135,6 +135,8 @@ Varyings vertUnlit(Attributes input, out float3 positionWS, uniform bool useEmis
     // Tint Map UV
     #if defined(_TINT_MAP_ENABLED) || defined(_TINT_MAP_3D_ENABLED)
     output.tintEmissionUV.xy = TRANSFORM_TINT_MAP(input.texcoord.xy);
+    output.tintEmissionUV.x += GET_CUSTOM_COORD(_TintMapOffsetXCoord);
+    output.tintEmissionUV.y += GET_CUSTOM_COORD(_TintMapOffsetYCoord);
     #endif
 
     // Tint Map Progress
@@ -239,7 +241,7 @@ half4 fragUnlit(in out Varyings input, uniform bool useEmission)
     // The valid range for parallax scale is usually between 0 and 0.1
     half parallaxScale = lerp(0, 0.1, _ParallaxStrength);
     half2 parallaxOffset = GetParallaxMappingUVOffset(input.parallaxMapUVAndProgress.xy, input.parallaxMapUVAndProgress.z, _ParallaxMapChannel, parallaxScale, input.viewDirTS);
-    
+
     #if defined(_PARALLAX_MAP_TARGET_BASE)
     input.baseMapUVAndProgresses.xy += parallaxOffset;
     #endif
@@ -252,7 +254,7 @@ half4 fragUnlit(in out Varyings input, uniform bool useEmission)
     input.tintEmissionUV.zw += parallaxOffset;
     #endif
     #endif
-    
+
     // Base Color
     half4 color = SAMPLE_BASE_MAP(input.baseMapUVAndProgresses.xy, input.baseMapUVAndProgresses.z);
 
@@ -297,7 +299,7 @@ half4 fragUnlit(in out Varyings input, uniform bool useEmission)
                            _EmissionMapChannelsX);
         #endif
     }
-    
+
     // Rim Transparency
     #ifdef _TRANSPARENCY_BY_RIM
     half rimTransparencyProgress = _RimTransparencyProgress + GET_CUSTOM_COORD(_RimTransparencyProgressCoord);

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.shader
@@ -38,7 +38,9 @@ Shader "Nova/Particles/UberUnlit"
         _TintMap3D("Tint Map 3D", 3D) = "" {}
         _TintMap3DProgress("Tint Map 3D Progress", Range(0, 1)) = 0.0
         _TintMap3DProgressCoord("Tint Map 3D Progress Coord", Float) = 0.0
-        _TintMapSliceCount("Base Map Slice Count", Float) = 4.0
+        _TintMapSliceCount("Tint Map Slice Count", Float) = 4.0
+        _TintMapOffsetXCoord("Tint Map Offset X Coord", Float) = 0.0
+        _TintMapOffsetYCoord("Tint Map Offset Y Coord", Float) = 0.0
         _TintBlendRate("Tint Blend Rate", Range(0.0, 1.0)) = 1.0
         _TintBlendRateCoord("Tint Blend Rate Coord", Float) = 0.0
         _TintRimProgress("Tint Rim Progress", Range(0.0, 1.0)) = 0.5
@@ -56,7 +58,7 @@ Shader "Nova/Particles/UberUnlit"
         _FlowIntensity("Flow Intensity", Float) = 1.0
         _FlowIntensityCoord("Flow Intensity Coord", Float) = 0.0
         _FlowMapTarget("Flow Map Target", Float) = 1.0
-        
+
         // Parallax Map
         _ParallaxMapMode("Emission Map Mode", Float) = 0.0
         _ParallaxMap("Parallax Map", 2D) = "" {}
@@ -129,7 +131,7 @@ Shader "Nova/Particles/UberUnlit"
         _DepthFadeNear("Depth Fade Near", Float) = 1.0
         _DepthFadeFar("Depth Fade Far", Float) = 10.0
         _DepthFadeWidth("Depth Fade Width", Float) = 1.0
-        
+
         // Vertex Deformation
         _VertexDeformationEnabled ("Vertex Deformation Enabled", Float) = 0
         _VertexDeformationMap ("Vertex Deformation Map", 2D) = "white" {}
@@ -138,7 +140,7 @@ Shader "Nova/Particles/UberUnlit"
         _VertexDeformationMapChannel("VertexDeformation Map Channel", Float) = 0.0
         _VertexDeformationIntensity("VertexDeformation Intensity", Float) = 0.1
         _VertexDeformationIntensityCoord("VertexDeformation Intensity Coord", Float) = 0.0
-        
+
         // Shadow Caster
         _ShadowCasterEnabled("Shadow Caster", Float) = 0
         _ShadowCasterApplyVertexDeformation("Shadow Caster Vertex Deformation Enabled", Float) = 0


### PR DESCRIPTION
## 作業内容
TintColorMapのOffsetにCustom Coords追加
<img width="547" alt="image" src="https://github.com/CyberAgentGameEntertainment/NovaShader/assets/119645979/c805f7c6-e758-4936-b427-b131dd91373d">

