### PR TITLE
ApplyTintColor()内のlerpの引数の型を明示するよう修正

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
@@ -445,7 +445,7 @@ inline void ApplyTintColor(in out half4 color, half2 uv, half progress, half ble
     #elif defined(_TINT_MAP_ENABLED) || defined(_TINT_MAP_3D_ENABLED)
     tintColor = SAMPLE_TINT_MAP(uv, progress);
     #endif
-    color *= lerp(1, tintColor, saturate(blendRate));
+    color *= lerp(half4(1, 1, 1, 1), tintColor, saturate(blendRate));
 }
 
 // Apply the color correction.


### PR DESCRIPTION
[こちらのissue](https://github.com/CyberAgentGameEntertainment/NovaShader/issues/78)の修正対応です。
PS5においてエラーが発生していたため、lerpの引数の型を明示的に同一にすることで対応しました。

---

Here is the fix for [this issue](https://github.com/CyberAgentGameEntertainment/NovaShader/issues/78).
We addressed the error on the PS5 by explicitly making the types of the arguments for the lerp function identical.
