### PR TITLE
Fixed a problem in Alpha Transition where Flip-Book Progress in Flip Book was not reflected correctly.

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonMaterialProperties.cs
@@ -141,6 +141,7 @@ namespace Nova.Editor.Core.Scripts
             AlphaTransitionMapSecondTextureOffsetXCoordProp.Setup(properties);
             AlphaTransitionMapSecondTextureOffsetYCoordProp.Setup(properties);
             AlphaTransitionMapSecondTextureChannelsXProp.Setup(properties);
+            AlphaTransitionMapSecondTextureSliceCountProp.Setup(properties);
             AlphaTransitionProgressSecondTextureProp.Setup(properties);
             AlphaTransitionProgressCoordSecondTextureProp.Setup(properties);
             DissolveSharpnessSecondTextureProp.Setup(properties);

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUber.hlsl
@@ -507,10 +507,10 @@ half GetTransitionAlphaImpl(half4 map, uint channel, half transitionProgress, fl
 }
 
 #if defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_AVERAGE) || defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_MULTIPLY)
-half GetTransitionAlpha(half2 transitionMapUv, half transitionMapProgress, half transitionProgress, half2 transitionMapSecondUv, half transitionProgressSecond)
+half GetTransitionAlpha(half2 transitionMapUv, half transitionMapProgress, half transitionProgress, half2 transitionMapSecondUv, half transitionMapProgressSecond, half transitionProgressSecond)
 {
     half4 mainTexMap = SAMPLE_ALPHA_TRANSITION_MAP(transitionMapUv, transitionMapProgress);
-    half4 secondTexMap = SAMPLE_ALPHA_TRANSITION_MAP_SECOND(transitionMapSecondUv, transitionMapProgress);
+    half4 secondTexMap = SAMPLE_ALPHA_TRANSITION_MAP_SECOND(transitionMapSecondUv, transitionMapProgressSecond);
     half mainTexAlpha = GetTransitionAlphaImpl(mainTexMap, (uint)_AlphaTransitionMapChannelsX, transitionProgress, _DissolveSharpness);
     half secondTexAlpha = GetTransitionAlphaImpl(secondTexMap, (uint)_AlphaTransitionMapSecondTextureChannelsX, transitionProgressSecond, _DissolveSharpnessSecondTexture);
     

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberUnlit.hlsl
@@ -48,6 +48,7 @@ struct Varyings
     #endif
     #if defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_AVERAGE) || defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_MULTIPLY)
     float4 flowTransitionSecondUVs : TEXCOORD11; // xy: FlowMap UV, zw: TransitionMap UV
+    float2 transitionEmissionProgressesSecond : TEXCOORD12; // x: TransitionMap Progress, y: EmissionMap Progress
     #endif
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
@@ -177,19 +178,23 @@ Varyings vertUnlit(Attributes input, out float3 positionWS, uniform bool useEmis
     #endif
 
     // Transition Map Progress
-    #if defined(_ALPHA_TRANSITION_MAP_MODE_2D_ARRAY) || defined(_ALPHA_TRANSITION_MAP_MODE_2D_ARRAY)
-    #if defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_AVERAGE) || defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_MULTIPLY)
-    float transitionMapProgress = _AlphaTransitionMapSecondTextureProgress + GET_CUSTOM_COORD(_AlphaTransitionMapSecondTextureProgressCoord);
-    float sliceCount = _AlphaTransitionMapSecondTextureSliceCount;
-    #else
+    #if defined(_ALPHA_TRANSITION_MAP_MODE_2D_ARRAY) || defined(_ALPHA_TRANSITION_MAP_MODE_3D)
     float transitionMapProgress = _AlphaTransitionMapProgress + GET_CUSTOM_COORD(_AlphaTransitionMapProgressCoord);
     float sliceCount = _AlphaTransitionMapSliceCount;
-    #endif
-
     #ifdef _ALPHA_TRANSITION_MAP_MODE_2D_ARRAY
     output.transitionEmissionProgresses.x = FlipBookProgress(transitionMapProgress, sliceCount);
     #elif _ALPHA_TRANSITION_MAP_MODE_3D
     output.transitionEmissionProgresses.x = FlipBookBlendingProgress(transitionMapProgress, sliceCount);
+    #endif
+
+    #if defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_AVERAGE) || defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_MULTIPLY)
+    float transitionMapProgressSecond = _AlphaTransitionMapSecondTextureProgress + GET_CUSTOM_COORD(_AlphaTransitionMapSecondTextureProgressCoord);
+    float sliceCountSecond = _AlphaTransitionMapSecondTextureSliceCount;
+    #ifdef _ALPHA_TRANSITION_MAP_MODE_2D_ARRAY
+    output.transitionEmissionProgressesSecond.x = FlipBookProgress(transitionMapProgressSecond, sliceCountSecond);
+    #elif _ALPHA_TRANSITION_MAP_MODE_3D
+    output.transitionEmissionProgressesSecond.x = FlipBookBlendingProgress(transitionMapProgressSecond, sliceCountSecond);
+    #endif
     #endif
     #endif
 
@@ -303,7 +308,7 @@ half4 fragUnlit(in out Varyings input, uniform bool useEmission)
     #if defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_AVERAGE) || defined(_ALPHA_TRANSITION_BLEND_SECOND_TEX_MULTIPLY)
     half alphaTransitionProgressSecondTexture = _AlphaTransitionProgressSecondTexture + GET_CUSTOM_COORD(_AlphaTransitionProgressCoordSecondTexture);
     ModulateAlphaTransitionProgress(alphaTransitionProgressSecondTexture, input.color.a);
-    color.a *= GetTransitionAlpha(input.flowTransitionUVs.zw, input.transitionEmissionProgresses.x, alphaTransitionProgress, input.flowTransitionSecondUVs.zw, alphaTransitionProgressSecondTexture);
+    color.a *= GetTransitionAlpha(input.flowTransitionUVs.zw, input.transitionEmissionProgresses.x, alphaTransitionProgress, input.flowTransitionSecondUVs.zw, input.transitionEmissionProgressesSecond.x, alphaTransitionProgressSecondTexture);
     #else
     color.a *= GetTransitionAlpha(input.flowTransitionUVs.zw, input.transitionEmissionProgresses.x, alphaTransitionProgress);
     #endif


### PR DESCRIPTION
ifdefの判定に誤りがあり、Alpha TransitionのMap ModeがFlip Book Blendingの場合にFlip-Book Progressの値が反映されない問題を修正しました。
また、２枚目のFlip BookのFlip-Book Progressパラメータが反映されない問題も修正しました。