### PR TITLE
Fix FixNow button functionality to include tangents in custom vertex streams when using ParallaxMap.

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/RendererErrorHandler.cs
+++ b/Assets/Nova/Editor/Core/Scripts/RendererErrorHandler.cs
@@ -238,12 +238,17 @@ namespace Nova.Editor.Core.Scripts
                 correctVertexStreams.Add(ParticleSystemVertexStream.Custom1XYZW);
                 correctVertexStreams.Add(ParticleSystemVertexStream.Custom2XYZW);
             }
-
-            if (material.shader.name == "Nova/Particles/UberLit"
-                && material.IsKeywordEnabled(ShaderKeywords.NormalMapEnabled))
+            
+            // Tangent
             {
-                correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Tangent);
-                correctVertexStreams.Add(ParticleSystemVertexStream.Tangent);
+                bool useParallaxMap = material.IsKeywordEnabled(ShaderKeywords.ParallaxMapTargetBase) ||
+                                      material.IsKeywordEnabled(ShaderKeywords.ParallaxMapTargetTint) ||
+                                      material.IsKeywordEnabled(ShaderKeywords.ParallaxMapTargetEmission);
+                if (useParallaxMap || (material.shader.name == "Nova/Particles/UberLit" && material.IsKeywordEnabled(ShaderKeywords.NormalMapEnabled)))
+                {
+                    correctVertexStreamsInstanced.Add(ParticleSystemVertexStream.Tangent);
+                    correctVertexStreams.Add(ParticleSystemVertexStream.Tangent);
+                }
             }
         }
 


### PR DESCRIPTION
ParallaxMapを利用する場合Custom Vertex StreamsにTangentが含まれるようFixNowボタンの処理を修正しました。