### PR TITLE
Alpha Transition: Fixed a bug where the tool would not set the texture reference to null when Mode is set to None.

### DIFF
--- a/Assets/Nova/Editor/Foundation/Scripts/UnusedReferencesRemover.cs
+++ b/Assets/Nova/Editor/Foundation/Scripts/UnusedReferencesRemover.cs
@@ -174,10 +174,22 @@ namespace Nova.Editor.Foundation.Scripts
 
         private static void FixAlphaTransition(Material material)
         {
-            var mode = (AlphaTransitionMapMode)material.GetFloat(MaterialPropertyNames.AlphaTransitionMapMode);
+            var mode = (AlphaTransitionMode)material.GetFloat(MaterialPropertyNames.AlphaTransitionMode);
+            if (mode == AlphaTransitionMode.None)
+            {
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMap);
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMap2DArray);
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMap3D);
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMapSecondTexture);
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMapSecondTexture2DArray);
+                ClearTexture(material, MaterialPropertyNames.AlphaTransitionMapSecondTexture3D);
+                return;
+            }
+
+            var mapMode = (AlphaTransitionMapMode)material.GetFloat(MaterialPropertyNames.AlphaTransitionMapMode);
             // 1st Texture
             {
-                switch (mode)
+                switch (mapMode)
                 {
                     case AlphaTransitionMapMode.SingleTexture:
                         ClearTexture(material, MaterialPropertyNames.AlphaTransitionMap2DArray);
@@ -207,7 +219,7 @@ namespace Nova.Editor.Foundation.Scripts
                 }
                 else
                 {
-                    switch (mode)
+                    switch (mapMode)
                     {
                         case AlphaTransitionMapMode.SingleTexture:
                             ClearTexture(material, MaterialPropertyNames.AlphaTransitionMapSecondTexture2DArray);

--- a/Assets/Samples/Materials/Sample01/mat_eff_firetubu_add02.mat
+++ b/Assets/Samples/Materials/Sample01/mat_eff_firetubu_add02.mat
@@ -32,7 +32,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: eb56350851cf1174284008a6c9bc5ecb, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 2, y: 2}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample02/mat_eff_crosslight01.mat
+++ b/Assets/Samples/Materials/Sample02/mat_eff_crosslight01.mat
@@ -32,7 +32,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 8b63af7713467a24997290fdb0ba9395, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample02/mat_eff_spk_lightball02.mat
+++ b/Assets/Samples/Materials/Sample02/mat_eff_spk_lightball02.mat
@@ -31,7 +31,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 8b63af7713467a24997290fdb0ba9395, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample03/mat_eff_lighttubu.mat
+++ b/Assets/Samples/Materials/Sample03/mat_eff_lighttubu.mat
@@ -33,7 +33,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: eb56350851cf1174284008a6c9bc5ecb, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 2, y: 2}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample03/mat_eff_thunder05.mat
+++ b/Assets/Samples/Materials/Sample03/mat_eff_thunder05.mat
@@ -34,7 +34,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 643a2212aa221d84887de9d5d3cb3f2d, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample06/mat_eff_barrier01.mat
+++ b/Assets/Samples/Materials/Sample06/mat_eff_barrier01.mat
@@ -32,7 +32,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: cbb14a957ee71374ea0c20fbded83dd5, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample06/mat_eff_ring01.mat
+++ b/Assets/Samples/Materials/Sample06/mat_eff_ring01.mat
@@ -32,7 +32,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 8b95cd3e06b11244cbaf76cb135c08e2, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample09/mat_eff_flare01.mat
+++ b/Assets/Samples/Materials/Sample09/mat_eff_flare01.mat
@@ -32,7 +32,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: faa6c86f83004024ba275f61f26af934, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 0.2, y: 0.5}
         m_Offset: {x: 0.4, y: 0.25}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample09/mat_eff_sphere01_parent.mat
+++ b/Assets/Samples/Materials/Sample09/mat_eff_sphere01_parent.mat
@@ -37,7 +37,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 5fb27c8353d25aa4ab705907dd9ade52, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample11/mat_eff_sphere_black01.mat
+++ b/Assets/Samples/Materials/Sample11/mat_eff_sphere_black01.mat
@@ -35,7 +35,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: eb56350851cf1174284008a6c9bc5ecb, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 3, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample12/mat_eff_tubu01.mat
+++ b/Assets/Samples/Materials/Sample12/mat_eff_tubu01.mat
@@ -45,7 +45,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: aaaed20355dc2dc47a9c65d04af94c27, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/Sample12/mat_eff_tubu02.mat
+++ b/Assets/Samples/Materials/Sample12/mat_eff_tubu02.mat
@@ -45,7 +45,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: aaaed20355dc2dc47a9c65d04af94c27, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Samples/Materials/SampleLit/mat_lit_01.mat
+++ b/Assets/Samples/Materials/SampleLit/mat_lit_01.mat
@@ -47,7 +47,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _AlphaTransitionMap:
-        m_Texture: {fileID: 2800000, guid: 5b82920c3b4f6eb4a83a6e5b98cff1e3, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 3, y: 2}
         m_Offset: {x: 0, y: 0}
     - _AlphaTransitionMap2DArray:

--- a/Assets/Tests/Editor/EditorTests/UnusedReferencesRemoverTest.cs
+++ b/Assets/Tests/Editor/EditorTests/UnusedReferencesRemoverTest.cs
@@ -85,6 +85,8 @@ namespace Tests.Editor
 
             // AlphaTransition
             {
+                material.SetFloat(MaterialPropertyNames.AlphaTransitionMode,
+                    (float)AlphaTransitionMode.Fade);
                 material.SetTexture(MaterialPropertyNames.AlphaTransitionMap, new Texture2D(1, 1));
                 material.SetTexture(MaterialPropertyNames.AlphaTransitionMap2DArray,
                     new Texture2DArray(1, 1, 1, TextureFormat.RGBA32, false));


### PR DESCRIPTION
Alpha Transitionについて、ModeがNoneの場合にRemoveUnusedReferenceツールによってテクスチャ参照がnullにされない不具合を修正しました。
また、修正後のツールをサンプルマテリアルに適用しました。

テストコードを刷新したいと考えているので別PRで対応する予定です。