### PR TITLE
Fixed a bug that caused shader compilation when the DEBUG_DISPLAY keyword is enabled

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
@@ -255,7 +255,7 @@ void InitializeBakedGIData(VaryingsLit input, inout InputData inputData)
     #endif
 
     #if defined(DEBUG_DISPLAY)
-    #if not defined(LIGHTMAP_ON)
+    #ifndef LIGHTMAP_ON
     inputData.vertexSH = input.vertexSH;
     #endif
     #if defined(USE_APV_PROBE_OCCLUSION)

--- a/Assets/Nova/package.json
+++ b/Assets/Nova/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.co.cyberagent.nova",
   "displayName": "NOVA Shader",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "unity": "2021.3",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
#if defined(DEBUG_DISPLAY)内に不適切なifディレクティブを使っていたため、DEBUG_DISPLAYキーワードが有効な場合にシェーダーコンパイルエラーが発生する問題を修正しました。