### PR TITLE
最低保証のバージョンを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
 [![license](https://img.shields.io/badge/PR-welcome-green.svg)](https://github.com/CyberAgentGameEntertainment/NovaShader/pulls)
-[![license](https://img.shields.io/badge/Unity-2020.3-green.svg)](#Requirements)
+[![license](https://img.shields.io/badge/Unity-2021.3-green.svg)](#Requirements)
 
 **Docs** ([English](README.md), [日本語](README_JA.md))
 | **Samples** ([English](Assets/Samples/README.md), [日本語](Assets/Samples/README_JA.md))

--- a/README_JA.md
+++ b/README_JA.md
@@ -7,7 +7,7 @@
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
 [![license](https://img.shields.io/badge/PR-welcome-green.svg)](https://github.com/CyberAgentGameEntertainment/NovaShader/pulls)
-[![license](https://img.shields.io/badge/Unity-2020.3-green.svg)](#Requirements)
+[![license](https://img.shields.io/badge/Unity-2021.3-green.svg)](#Requirements)
 
 **ドキュメント** ([English](README.md), [日本語](README_JA.md))
 | **サンプル** ([English](Assets/Samples/README.md), [日本語](Assets/Samples/README_JA.md))


### PR DESCRIPTION
下記のPRでNova 2.0になって最低保証バージョンが2021のLTSになっていたのですが、Readmeの記載が更新されていなかったので守勢しました。

https://github.com/CyberAgentGameEntertainment/NovaShader/releases/tag/2.0.0