### PR TITLE
Fixed a bug that prevented GI from being applied when using old-style light probes in the Unity6000

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
@@ -240,7 +240,6 @@ void InitializeBakedGIData(VaryingsLit input, inout InputData inputData)
     // Does not support light maps.
     #if defined(DYNAMICLIGHTMAP_ON)
     // inputData.bakedGI = SAMPLE_GI(input.staticLightmapUV, input.dynamicLightmapUV, input.vertexSH, inputData.normalWS);
-    // inputData.shadowMask = SAMPLE_SHADOWMASK(input.staticLightmapUV);
     #elif !defined(LIGHTMAP_ON) && (defined(PROBE_VOLUMES_L1) || defined(PROBE_VOLUMES_L2))
     inputData.bakedGI = SAMPLE_GI(input.vertexSH,
         GetAbsolutePositionWS(inputData.positionWS),
@@ -250,8 +249,7 @@ void InitializeBakedGIData(VaryingsLit input, inout InputData inputData)
         input.probeOcclusion,
         inputData.shadowMask);
     #else
-    // inputData.bakedGI = SAMPLE_GI(input.staticLightmapUV, input.vertexSH, inputData.normalWS);
-    // inputData.shadowMask = SAMPLE_SHADOWMASK(input.staticLightmapUV);
+    inputData.bakedGI = SampleSHPixel(input.vertexSH, inputData.normalWS);
     #endif
 
     #if defined(DEBUG_DISPLAY)

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLitForward.hlsl
@@ -237,10 +237,7 @@ VaryingsLit vertLit(AttributesLit input)
 void InitializeBakedGIData(VaryingsLit input, inout InputData inputData)
 {
     #if UNITY_VERSION >= 60000000
-    // Does not support light maps.
-    #if defined(DYNAMICLIGHTMAP_ON)
-    // inputData.bakedGI = SAMPLE_GI(input.staticLightmapUV, input.dynamicLightmapUV, input.vertexSH, inputData.normalWS);
-    #elif !defined(LIGHTMAP_ON) && (defined(PROBE_VOLUMES_L1) || defined(PROBE_VOLUMES_L2))
+    #if !defined(LIGHTMAP_ON) && (defined(PROBE_VOLUMES_L1) || defined(PROBE_VOLUMES_L2))
     inputData.bakedGI = SAMPLE_GI(input.vertexSH,
         GetAbsolutePositionWS(inputData.positionWS),
         inputData.normalWS,


### PR DESCRIPTION
Unity6000環境で旧式のライトプローブを利用している際にGIを適用できていない不具合の修正をしました