### PR TITLE
 Implementation of Custom Trail Vertex Streams support

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesUberCommonGUI.cs
@@ -19,7 +19,7 @@ namespace Nova.Editor.Core.Scripts
         public ParticlesUberCommonGUI(MaterialEditor editor)
         {
             var material = editor.target as Material;
-            _renderersUsingThisMaterial = RendererErrorHandler.FindRendererWithMaterial(material);
+            _renderersUsingThisMaterial = RendererErrorHandler.FindAllRenderersWithMaterial(material);
         }
 
         public void Setup(MaterialEditor editor, ParticlesUberCommonMaterialProperties commonMaterialProperties)
@@ -27,7 +27,7 @@ namespace Nova.Editor.Core.Scripts
             _editor = editor;
             _commonMaterialProperties = commonMaterialProperties;
             RendererErrorHandler.SetupCorrectVertexStreams(_editor.target as Material, out _correctVertexStreams,
-                out _correctVertexStreamsInstanced, _commonMaterialProperties);
+                out _correctVertexStreamsInstanced, out _correctTrailVertexStreams, out _correctTrailVertexStreamsInstanced, _commonMaterialProperties);
         }
 
         public void DrawRenderSettingsProperties(Action drawPropertiesFunc)
@@ -109,12 +109,12 @@ namespace Nova.Editor.Core.Scripts
 
         public void DrawFixNowButton()
         {
-            if (!RendererErrorHandler.CheckError(_renderersUsingThisMaterial, _correctVertexStreams,
-                    _correctVertexStreamsInstanced))
+            if (!RendererErrorHandler.CheckError(_renderersUsingThisMaterial, _editor.target as Material, _correctVertexStreams,
+                    _correctVertexStreamsInstanced, _correctTrailVertexStreams, _correctTrailVertexStreamsInstanced))
                 return;
 
             EditorGUILayout.HelpBox(
-                "Some particle System Renderers are using this material with incorrect Vertex Streams.\n" +
+                "Some particle System Renderers are using this material with incorrect Vertex Streams or Trail Vertex Streams.\n" +
                 "Recommend that you press the Fix Now button to correct the error."
                 , MessageType.Error, true);
             if (GUILayout.Button(StreamApplyToAllSystemsText, EditorStyles.miniButton,
@@ -123,8 +123,8 @@ namespace Nova.Editor.Core.Scripts
                 Undo.RecordObjects(
                     _renderersUsingThisMaterial.Where(r => r != null).ToArray(),
                     "Apply custom vertex streams from material");
-                RendererErrorHandler.FixError(_renderersUsingThisMaterial, _correctVertexStreams,
-                    _correctVertexStreamsInstanced);
+                RendererErrorHandler.FixError(_renderersUsingThisMaterial, _editor.target as Material, _correctVertexStreams,
+                    _correctVertexStreamsInstanced, _correctTrailVertexStreams, _correctTrailVertexStreamsInstanced);
             }
         }
 
@@ -711,6 +711,10 @@ namespace Nova.Editor.Core.Scripts
         private List<ParticleSystemVertexStream> _correctVertexStreams = new();
 
         private List<ParticleSystemVertexStream> _correctVertexStreamsInstanced = new();
+
+        private List<ParticleSystemVertexStream> _correctTrailVertexStreams = new();
+
+        private List<ParticleSystemVertexStream> _correctTrailVertexStreamsInstanced = new();
 
         # endregion
     }

--- a/Assets/Nova/package.json
+++ b/Assets/Nova/package.json
@@ -2,7 +2,7 @@
   "name": "jp.co.cyberagent.nova",
   "displayName": "NOVA Shader",
   "version": "3.0.1",
-  "unity": "2022.1",
+  "unity": "2022.3",
   "license": "MIT",
   "dependencies": {
   },

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For more information, please refer to the following documents, [Samples](Assets/
 ### Requirements
 This library is compatible with the following environments.
 
-* Unity 2022.1 or higher
+* Unity 2022.3 LTS or higher
 * Universal Render Pipeline
 * Shader Model 3.5
 
@@ -1441,6 +1441,7 @@ If checked, Transparency Luminance will affect Alpha value
 
 ## Use with the Custom Vertex Streams
 Using the Particle System's Custom Vertex Streams, you can animate the properties of the Material.
+The shader supports both regular vertex streams and trail vertex streams.
 In the following example, we will use the Custom Vertex Streams to rotate the texture.
 
 #### Set up the Custom Data
@@ -1508,13 +1509,13 @@ Now you can use `Mesh GPU Instancing`.
 We have seen several cases where Custom Vertex Streams are set up manually.<br/>
 In addition, the vertex streams required by the GPUs vary depending on their settings.<br/>
 
-It has a feature that automatically set up the Custom vertex streams as `Fix Now`.
+It has a feature that automatically set up the Custom vertex streams as `Fix Now`. The automatic setup feature supports both regular particle systems and trail vertex streams.
 
 #### Fix Now
 If vertex streams are different from what the CPUs require, <br/>
 `Fix Now` button and error will appear at bottom of the inspector.<br/>
 
-At this time, pressing this button will automatically set the typical vertex stream needed.
+At this time, pressing this button will automatically set the typical vertex stream needed. This feature works for both sharedMaterial and trailMaterial configurations, ensuring that all necessary vertex streams are properly configured.
 
 <p align="center">
   <img width="60%" src="https://user-images.githubusercontent.com/106138524/191191870-7b22351b-e826-4ccb-92c9-693009133909.png" alt="Fix Now"><br>

--- a/README_JA.md
+++ b/README_JA.md
@@ -95,7 +95,7 @@
 #### 要件
 本ライブラリは以下の環境に対応しています。
 
-* Unity 2022.1 以上
+* Unity 2022.3 LTS 以上
 * Universal Render Pipeline
 * Shader Model 3.5
 
@@ -1447,6 +1447,7 @@ Alpha値がCutoff値以下の部分は影を落とさなくなります（描画
 
 ## Custom Vertex Streamsとの連携
 Particle SystemのCustom Vertex Streamsを使うと、マテリアルのプロパティを自由にアニメーションさせることができます。  
+シェーダーは通常の頂点ストリームと、トレイル頂点ストリームの両方をサポートしています。  
 以下では例として、Custom Vertex Streamsを使ってテクスチャを回転させる手順を説明します。
 
 #### Custom Dataを設定
@@ -1515,12 +1516,12 @@ Particle SystemのCustom Vertex Streamsを使うと、マテリアルのプロ�
 ここまでCustom Vertex Streamsを手動で設定するいくつかのケースを見てきました。<br/>
 これ以外にもGPUが求めている頂点ストリームは各種設定によって変わっていきます。<br/>
 
-この頂点ストリームを自動的に設定する機能`Fix Now`があります。<br/>
+この頂点ストリームを自動的に設定する機能`Fix Now`があります。自動設定機能は通常のパーティクルシステムとトレイル頂点ストリームの両方をサポートしています。<br/>
 
 #### Fix Now
 GPUが求めている頂点ストリームとの差異が生じている時に、<br/>
 マテリアルインスペクターの下部にエラーメッセージとエラーを修正するためのボタンが表示されています。<br/><br/>
-この時、このボタンを押すことで、必要とされている典型的な頂点ストリームが自動的に設定されます。<br/>
+この時、このボタンを押すことで、必要とされている典型的な頂点ストリームが自動的に設定されます。この機能はsharedMaterialとtrailMaterialの両方の設定に対応し、必要なすべての頂点ストリームが適切に構成されることを保証します。<br/>
 
 <p align="center">
   <img width="60%" src="https://user-images.githubusercontent.com/106138524/191191870-7b22351b-e826-4ccb-92c9-693009133909.png" alt="Fix Now"><br>


### PR DESCRIPTION
  Unity 2022.3 LTS以降で利用可能になったCustom Trail Vertex Streamsに対応する機能を実装しました。

  - Trail Vertex Streamsの自動エラー検出・修正機能を追加
  - 通常のVertex Streamsと同様の機能をTrail Vertex Streamsでも利用可能に
  - sharedMaterialとtrailMaterialの両方を統合的にチェック・修正する仕組みを実装
  - Unity 2022.3 LTS以降を最小要件として設定