### PR TITLE
Add SceneSelectionPass/Picking pass to ParticlesDistortion shader to fix selection outline

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortion.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortion.shader
@@ -100,6 +100,88 @@ Shader "Nova/Particles/Distortion"
             #include "ParticlesDistortionForward.hlsl"
             ENDHLSL
         }
+
+        Pass
+        {
+            Tags
+            {
+                "LightMode" = "SceneSelectionPass"
+            }
+
+            BlendOp Add
+            Blend One Zero
+            ZWrite On
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma vertex vertEditor
+            #pragma fragment fragSceneHighlight
+            #pragma target 3.5
+
+            // Unity Defined
+            #pragma multi_compile_instancing
+            #pragma instancing_options procedural:ParticleInstancingSetup
+
+            // Base Color
+            #pragma shader_feature_local_vertex _BASE_MAP_ROTATION_ENABLED
+            #pragma shader_feature_local_fragment _ _BASE_SAMPLER_STATE_POINT_MIRROR _BASE_SAMPLER_STATE_LINEAR_MIRROR _BASE_SAMPLER_STATE_TRILINEAR_MIRROR
+
+            // Flow Map
+            #pragma shader_feature_local _FLOW_MAP_ENABLED // Obsolete, but retained for compatibility.
+            #pragma shader_feature_local _FLOW_MAP_TARGET_BASE
+            #pragma shader_feature_local _FLOW_MAP_TARGET_ALPHA_TRANSITION
+
+            // Alpha Transition
+            #pragma shader_feature_local _ _FADE_TRANSITION_ENABLED _DISSOLVE_TRANSITION_ENABLED
+
+            // Transparency
+            #pragma shader_feature_local _SOFT_PARTICLES_ENABLED
+            #pragma shader_feature_local _DEPTH_FADE_ENABLED
+
+            #include "ParticlesDistortionEditor.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Tags
+            {
+                "LightMode" = "Picking"
+            }
+
+            BlendOp Add
+            Blend One Zero
+            ZWrite On
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma vertex vertEditor
+            #pragma fragment fragScenePicking
+            #pragma target 3.5
+
+            // Unity Defined
+            #pragma multi_compile_instancing
+            #pragma instancing_options procedural:ParticleInstancingSetup
+
+            // Base Color
+            #pragma shader_feature_local_vertex _BASE_MAP_ROTATION_ENABLED
+            #pragma shader_feature_local_fragment _ _BASE_SAMPLER_STATE_POINT_MIRROR _BASE_SAMPLER_STATE_LINEAR_MIRROR _BASE_SAMPLER_STATE_TRILINEAR_MIRROR
+
+            // Flow Map
+            #pragma shader_feature_local _FLOW_MAP_ENABLED // Obsolete, but retained for compatibility.
+            #pragma shader_feature_local _FLOW_MAP_TARGET_BASE
+            #pragma shader_feature_local _FLOW_MAP_TARGET_ALPHA_TRANSITION
+
+            // Alpha Transition
+            #pragma shader_feature_local _ _FADE_TRANSITION_ENABLED _DISSOLVE_TRANSITION_ENABLED
+
+            // Transparency
+            #pragma shader_feature_local _SOFT_PARTICLES_ENABLED
+            #pragma shader_feature_local _DEPTH_FADE_ENABLED
+
+            #include "ParticlesDistortionEditor.hlsl"
+            ENDHLSL
+        }
     }
 
     CustomEditor "Nova.Editor.Core.Scripts.ParticlesDistortionGUI"

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortionEditor.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortionEditor.hlsl
@@ -1,0 +1,36 @@
+#ifndef NOVA_PARTICLESDISTORTIONEDITOR_INCLUDED
+#define NOVA_PARTICLESDISTORTIONEDITOR_INCLUDED
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+#include "ParticlesDistortionForward.hlsl"
+
+float _ObjectId;
+float _PassValue;
+float4 _SelectionID;
+
+Varyings vertEditor(Attributes input)
+{
+    return vert(input);
+}
+
+half4 fragSceneHighlight(Varyings input) : SV_Target
+{
+    UNITY_SETUP_INSTANCE_ID(input);
+    
+    // Call frag function to perform alpha test and other visibility checks
+    frag(input);
+    
+    return float4(_ObjectId, _PassValue, 1, 1);
+}
+
+half4 fragScenePicking(Varyings input) : SV_Target
+{
+    UNITY_SETUP_INSTANCE_ID(input);
+    
+    // Call frag function to perform alpha test and other visibility checks
+    frag(input);
+    
+    return _SelectionID;
+}
+
+#endif

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortionEditor.hlsl.meta
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesDistortionEditor.hlsl.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7c8a9e5b3f2d4e04a9b8c6f5d3e2a1b0
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ParticleSystemのRenderModeをMeshに指定している場合に 、アウトラインが不正な位置に描画される問題を修正しました。
この対応として、ParticlesDistortionシェーダーにSceneSelectionPassとPickingパスを追加しました。