### PR TITLE
Fix shader optimization regex bug preventing keyword deletion

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/Optimizer/OptimizedShaderGenerator.cs
+++ b/Assets/Nova/Editor/Core/Scripts/Optimizer/OptimizedShaderGenerator.cs
@@ -325,7 +325,7 @@ namespace Nova.Editor.Core.Scripts.Optimizer
             @"_TRANSPARENCY_BY_RIM\b|" +
             @"_SOFT_PARTICLES_ENABLED\b|" +
             @"_DEPTH_FADE_ENABLED\b" +
-            @")\b.",
+            @")\b",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex PassStartRegex = new(


### PR DESCRIPTION
## 概要

OptimizedShaderGeneratorのShaderKeywordRegexにおける正規表現の末尾のドット文字によるキーワードマッチング・削除の阻害バグを修正しました。
- `@")\b."`の末尾のドットを削除 → `@")\b"`

テストは実行済みです。