### PR TITLE
Add Forward+ rendering support

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
@@ -240,6 +240,7 @@ Shader "Nova/Particles/UberLit"
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
             #if UNITY_VERSION >= 60000000
             #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"

--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
@@ -239,6 +239,7 @@ Shader "Nova/Particles/UberLit"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile _ _FORWARD_PLUS
             #if UNITY_VERSION >= 60000000
             #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"

--- a/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
@@ -255,6 +255,7 @@ Shader "Nova/UIParticles/UberLit"
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
             // Render Settings
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS

--- a/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
@@ -254,6 +254,7 @@ Shader "Nova/UIParticles/UberLit"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile _ _FORWARD_PLUS
 
             // Render Settings
             #pragma shader_feature_local_fragment _VERTEX_ALPHA_AS_TRANSITION_PROGRESS

--- a/Assets/Settings/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Assets/Settings/UniversalRenderPipelineAsset_Renderer.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 2
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0

--- a/Assets/Settings/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Assets/Settings/UniversalRenderPipelineAsset_Renderer.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 2
+  m_RenderingMode: 0
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0


### PR DESCRIPTION
## 概要
NOVA ShaderにUnity URP Forward+レンダリングパスのサポートを追加しました。

## 変更内容
- `ParticlesUberLit.shader`、`UIParticlesUberLit.shader`に以下を追加：
  - `#pragma multi_compile _ _FORWARD_PLUS`
  - `#include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"`