### PR TITLE
fix: Enabling post-processing for the Test_Distortion camera

### DIFF
--- a/Assets/Tests/Scenes/Test_Distortion.unity
+++ b/Assets/Tests/Scenes/Test_Distortion.unity
@@ -1192,7 +1192,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0


### PR DESCRIPTION
https://github.com/CyberAgentGameEntertainment/NovaShader/pull/159 でDistortion Pass内で参照するPostProcessの有効化設定をカメラ側のものを参照するよう修正しましたが、Distortionのテストシーンのカメラの設定でPost Processingが無効になっており、描画結果にDistortionが適用されずテストに失敗するようになっていました。
そのためカメラ設定のPost Processingを有効にすることで修正しました。