### PR TITLE
Support Unity 6.1 _CLUSTER_LIGHT_LOOP keyword

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberLit.shader
@@ -268,7 +268,11 @@ Shader "Nova/Particles/UberLit"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #if UNITY_VERSION >= 60100001
+            #pragma multi_compile _ _CLUSTER_LIGHT_LOOP
+            #else
             #pragma multi_compile _ _FORWARD_PLUS
+            #endif
             #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
             #if UNITY_VERSION >= 60000000
             #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX

--- a/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
+++ b/Assets/Nova/Runtime/Core/Shaders/UIParticlesUberLit.shader
@@ -273,7 +273,11 @@ Shader "Nova/UIParticles/UberLit"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #if UNITY_VERSION >= 60100001
+            #pragma multi_compile _ _CLUSTER_LIGHT_LOOP
+            #else
             #pragma multi_compile _ _FORWARD_PLUS
+            #endif
             #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
             // Render Settings


### PR DESCRIPTION
## Summary
- Unity 6.1で`_FORWARD_PLUS`キーワードが`_CLUSTER_LIGHT_LOOP`に変更されたことに対応
- Unityバージョンによる条件分岐を追加し、後方互換性を維持

## Changes
- `ParticlesUberLit.shader`: Unity 6.1以降で`_CLUSTER_LIGHT_LOOP`、それ以前で`_FORWARD_PLUS`を使用
- `UIParticlesUberLit.shader`: 同様の条件分岐を追加

## Test plan
- [ ] Unity 6.0でシェーダーが正しくコンパイルされることを確認
- [ ] Unity 6.1でシェーダーが正しくコンパイルされることを確認
- [ ] 各Unityバージョンでレンダリング結果に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)