### PR TITLE
Fix: Apply Vertex Deformation in Depth Passes

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
@@ -177,6 +177,21 @@ VaryingsDrawDepth vert(AttributesDrawDepth input)
     SETUP_CUSTOM_COORD(input)
     TRANSFER_CUSTOM_COORD(input, output);
     #endif
+
+    // Vertex Deformation
+    #ifdef _VERTEX_DEFORMATION_ENABLED
+    float2 vertexDeformationUVs = TRANSFORM_TEX(input.texcoord.xy, _VertexDeformationMap);
+    vertexDeformationUVs.x += GET_CUSTOM_COORD(_VertexDeformationMapOffsetXCoord);
+    vertexDeformationUVs.y += GET_CUSTOM_COORD(_VertexDeformationMapOffsetYCoord);
+    float vertexDeformationIntensity = _VertexDeformationIntensity + GET_CUSTOM_COORD(_VertexDeformationIntensityCoord);
+    vertexDeformationIntensity = GetVertexDeformationIntensity(
+        _VertexDeformationMap, sampler_VertexDeformationMap,
+        vertexDeformationIntensity,
+        vertexDeformationUVs,
+        _VertexDeformationMapChannel,
+        _VertexDeformationBaseValue);
+    input.positionOS.xyz += normalize(input.normalOS) * vertexDeformationIntensity;
+    #endif
     InitializeVertexOutputDrawDepth(input, output);
 
     #ifdef _USE_BASE_MAP_UV


### PR DESCRIPTION
DepthNormals/DepthOnlyパスにおいて、Vertex Deformationが適用されていなかった問題を修正しました。

  ## 問題点

  Vertex Deformation機能は以下のパスで実装されていました：
  - ✅ Forward Pass（`ParticlesUberUnlit.hlsl`）
  - ✅ ShadowCaster Pass（`ParticlesUberShadowCaster.hlsl`）

  しかし、DepthNormals/DepthOnlyパス（`ParticlesUberDepthNormalsCore.hlsl`）では実装されていませんでした。

  シェーダーファイルでは `_VERTEX_DEFORMATION_ENABLED` キーワードが宣言されているものの、実際のVertex
  Deformationコードが欠落していました。

  ## 影響範囲

  この問題により、以下の視覚的な不具合が発生する可能性がありました：
  - Screen Space Ambient Occlusion（SSAO）の不正確な描画
  - Depth-based effects（フォグ、Depth Fade、Soft Particlesなど）でのアーティファクト
  - Deferred Renderingにおける法線ベースのライティングの不整合
  - アウトラインエフェクト（深度/法線を使用）の位置ずれ

  ## 修正内容

  `ParticlesUberDepthNormalsCore.hlsl` の `vert()` 関数において、`InitializeVertexOutputDrawDepth()`
  呼び出しの前にVertex Deformationコードを追加しました。