### PR TITLE
Enable Base Map UV when Vertex Deformation is used in Depth pass

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl
@@ -7,7 +7,7 @@
 
 // If defined _ALPHATEST_ENABLED or  _NORMAL_MAP_ENABLED, base map uv is enabled.
 // Also enabled if TintColor FlipBook or 3D features are used.
-#if defined( _ALPHATEST_ENABLED ) || defined(_NORMAL_MAP_ENABLED) || defined(_TINT_MAP_MODE_2D_ARRAY) || defined(_TINT_MAP_3D_ENABLED)
+#if defined( _ALPHATEST_ENABLED ) || defined(_NORMAL_MAP_ENABLED) || defined(_TINT_MAP_MODE_2D_ARRAY) || defined(_TINT_MAP_3D_ENABLED) || defined(_VERTEX_DEFORMATION_ENABLED)
 #define _USE_BASE_MAP_UV
 #endif
 


### PR DESCRIPTION
## 概要

Depth/NormalsパスでVertex Deformationが有効な場合に、Base Map UVを有効化する修正です。

## 問題

コミット`efd64a02`でDepth/NormalsパスにVertex Deformationの処理が追加されましたが、`_USE_BASE_MAP_UV`の定義条件に`_VERTEX_DEFORMATION_ENABLED`が含まれていませんでした。

Vertex Deformationの処理では以下のようにtexcoordからUVを取得する必要があります：

```hlsl
float2 vertexDeformationUVs = TRANSFORM_TEX(input.texcoord.xy, _VertexDeformationMap);
```

しかし、`_USE_BASE_MAP_UV`が定義されていない場合、`AttributesDrawDepth`構造体に`texcoord : TEXCOORD0`が含まれないため、コンパイルエラーまたは未定義動作が発生します。

## 解決策

`_USE_BASE_MAP_UV`の定義条件に`_VERTEX_DEFORMATION_ENABLED`を追加しました：

```hlsl
#if defined(_ALPHATEST_ENABLED) || defined(_NORMAL_MAP_ENABLED) || 
    defined(_TINT_MAP_MODE_2D_ARRAY) || defined(_TINT_MAP_3D_ENABLED) || 
    defined(_VERTEX_DEFORMATION_ENABLED)
#define _USE_BASE_MAP_UV
#endif
```

これにより、Vertex Deformationが有効な場合に必要なVertex Streams（TEXCOORD0）が正しく定義されます。

## 影響範囲

- DepthNormals/DepthOnlyパスのみ
- Vertex Deformationが有効なマテリアルのみ
- パフォーマンスへの影響は最小限（必要な場合のみVertex Streamsを追加）

## テスト

- [ ] Vertex Deformationを有効にしたマテリアルでDepth/Normalsパスが正しく動作すること
- [ ] 他のパス（Forward、ShadowCaster）に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)