### PR TITLE
Enable Normal WS in the Vertex Deformation

### DIFF
--- a/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
+++ b/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl
@@ -17,7 +17,7 @@
 
 #if defined(DEPTH_ONLY_PASS)
 #ifndef _ALPHATEST_ENABLED
-#ifndef FRAGMENT_USE_NORMAL_WS
+#ifndef _VERTEX_DEFORMATION_ENABLED
 #undef FRAGMENT_USE_NORMAL_WS // This symbol is not necessary when drawing opaque objects.
 #endif
 #endif


### PR DESCRIPTION
## 概要

Depth/Normalパスかつ、頂点変形機能を使用している際にシェーダーエラーが出てしまう不具合修正です。


## 問題

頂点変形機能では法線情報が必要なのですが、Depthパスでは定義を外されてしまっていました。

https://github.com/CyberAgentGameEntertainment/NovaShader/blob/dcbdd6b9c8ec1b9d9cdf210c4ce9bc1679955f14/Assets/Nova/Runtime/Core/Shaders/ParticlesUberDepthNormalsCore.hlsl#L193

https://github.com/CyberAgentGameEntertainment/NovaShader/blob/dcbdd6b9c8ec1b9d9cdf210c4ce9bc1679955f14/Assets/Nova/Runtime/Core/Shaders/Particles.hlsl#L18-L22

## 解決

当時はなかった機能のため、Depthパスかつ頂点変形機能が有効なときには定義を外さないようにしました。


## 動作確認

### 前提

`Test_Vertex_Deformation`シーンにて、強制的にDepth、もしくはDepthNormalPrepassをかかせるようにしています。

#### Depth

頂点の変形がDepthに書かれています。

<img width="668" height="380" alt="Depth" src="https://github.com/user-attachments/assets/01ce75d2-1084-448a-881c-8c0c5386ec5c" />

#### DepthNormal

こちらも同様にDepthNormalに書かれています。

<img width="668" height="380" alt="DepthNormal" src="https://github.com/user-attachments/assets/d7ba7528-3ff0-4d23-a269-88e371891186" />


## 確認したこと

- Depth, DepthNormalでDepthTextureに対して頂点変形機能で変えた頂点情報がかかれること
- Testが通ること
