### PR TITLE
Move shader keyword and pass changes to ShaderGUI.ValidateMaterial

### DIFF
--- a/Assets/Nova/Editor/Core/Scripts/ParticlesGUI.cs
+++ b/Assets/Nova/Editor/Core/Scripts/ParticlesGUI.cs
@@ -25,14 +25,12 @@ namespace Nova.Editor.Core.Scripts
             // Find properties every time to update the inspector when undo or redo is performed.
             SetupProperties(properties);
 
-            using (var changeCheckScope = new EditorGUI.ChangeCheckScope())
-            {
-                DrawGUI(editor, properties);
+            DrawGUI(editor, properties);
+        }
 
-                if (changeCheckScope.changed)
-                    foreach (var obj in editor.targets)
-                        MaterialChanged((Material)obj);
-            }
+        public override void ValidateMaterial(Material material)
+        {
+            MaterialChanged(material);
         }
 
         protected abstract void SetupProperties(MaterialProperty[] properties);


### PR DESCRIPTION
# 概要

シェーダーキーワード、Passの切り替えを`ShaderGUI.ValidateMaterial`に変更しました。

https://docs.unity3d.com/6000.2/Documentation/ScriptReference/ShaderGUI.ValidateMaterial.html

# 動作確認

## 前提

どちらも空のシーンに、PlaneとCubeを配置しています。
PlaneはMeshRendererの`CastShadows`をOffに、
Cubeは、UberLitシェーダーをアタッチしたマテリアルを刺しています。

## シェーダーキーワードの切り替え

シェーダーの`Transparency`のRimのToggleの切り替えで、該当のキーワードである
`_TRANSPARENCY_BY_RIM`が切り替わっています。


https://github.com/user-attachments/assets/fb0f2f60-72fb-464f-8704-c715969a4826


## Passの切り替え

シェーダーの`ShadowCaster`のToggleの切り替えで、該当のPassである
MainLightShadowの有効/無効が切り替わっています。

https://github.com/user-attachments/assets/3670b5cb-d77b-435d-b24f-17933cfbcc1c


# 確認したこと

- 各種シェーダーで、キーワードおよびパスが切り替わること
- 2022.3, Unity6環境でテストが通ること

