### PR TITLE
Cache SystemInfo format checks to avoid GC allocation

### DIFF
--- a/Assets/Nova/Runtime/Core/Scripts/DistortedUvBufferPass.cs
+++ b/Assets/Nova/Runtime/Core/Scripts/DistortedUvBufferPass.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 
+#if UNITY_2023_3_OR_NEWER
+using UnityEngine.Experimental.Rendering;
+#endif
+
 namespace Nova.Runtime.Core.Scripts
 {
     public partial class DistortedUvBufferPass : ScriptableRenderPass
@@ -19,11 +23,21 @@ namespace Nova.Runtime.Core.Scripts
 
         private RTHandle _renderTargetRTHandle;
 
+#if UNITY_2023_3_OR_NEWER
+        private readonly GraphicsFormat _colorFormat;
+#endif
+
         public DistortedUvBufferPass(string lightMode)
         {
             _filteringSettings = new FilteringSettings(_renderQueueRange);
             renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
             _shaderTagId = new ShaderTagId(lightMode);
+
+#if UNITY_2023_3_OR_NEWER
+            _colorFormat = SystemInfo.IsFormatSupported(GraphicsFormat.R16G16_SFloat, GraphicsFormatUsage.Render)
+                ? GraphicsFormat.R16G16_SFloat
+                : GraphicsFormat.None;
+#endif
         }
 
         public void Setup(RTHandle renderTargetRTHandle)

--- a/Assets/Nova/Runtime/Core/Scripts/DistortedUvBufferPass_RenderGraph.cs
+++ b/Assets/Nova/Runtime/Core/Scripts/DistortedUvBufferPass_RenderGraph.cs
@@ -48,15 +48,15 @@ namespace Nova.Runtime.Core.Scripts
             }
         }
 
-        private static TextureHandle CreateRenderTarget(RenderGraph renderGraph, ContextContainer frameData)
+        private TextureHandle CreateRenderTarget(RenderGraph renderGraph, ContextContainer frameData)
         {
             var resourceData = frameData.Get<UniversalResourceData>();
             var desc = renderGraph.GetTextureDesc(resourceData.activeColorTexture);
             desc.name = DistortedUvBufferTexName;
             desc.depthBufferBits = 0;
             desc.clearColor = Color.gray;
-            if (SystemInfo.IsFormatSupported(GraphicsFormat.R16G16_SFloat, GraphicsFormatUsage.Render))
-                desc.colorFormat = GraphicsFormat.R16G16_SFloat;
+            if (_colorFormat != GraphicsFormat.None)
+                desc.colorFormat = _colorFormat;
             return renderGraph.CreateTexture(desc);
         }
 

--- a/Assets/Nova/Runtime/Core/Scripts/ScreenSpaceDistortion.cs
+++ b/Assets/Nova/Runtime/Core/Scripts/ScreenSpaceDistortion.cs
@@ -22,10 +22,16 @@ namespace Nova.Runtime.Core.Scripts
 
         private RTHandle _distortedUvBufferRTHandle;
 
+        private RenderTextureFormat _distortedUvBufferFormat;
+
         public override void Create()
         {
             _applyDistortionShader = Shader.Find("Hidden/Nova/Particles/ApplyDistortion");
             if (_applyDistortionShader == null) return;
+
+            _distortedUvBufferFormat = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.RGHalf)
+                ? RenderTextureFormat.RGHalf
+                : RenderTextureFormat.DefaultHDR;
 
             _distortedUvBufferPass = new DistortedUvBufferPass(DistortionLightMode);
             _applyDistortionPass = new ApplyDistortionPass(_applyToSceneView, _applyDistortionShader);
@@ -46,17 +52,13 @@ namespace Nova.Runtime.Core.Scripts
                 || !IsPostProcessingAllowed(ref renderingData))
                 return;
 
-            var distortedUvBufferFormat = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.RGHalf)
-                ? RenderTextureFormat.RGHalf
-                : RenderTextureFormat.DefaultHDR;
-
 #if UNITY_2023_3_OR_NEWER
             if (GraphicsSettings.GetRenderPipelineSettings<RenderGraphSettings>().enableRenderCompatibilityMode)
 #endif
             {
                 var desc = renderingData.cameraData.cameraTargetDescriptor;
                 desc.depthBufferBits = 0;
-                desc.colorFormat = distortedUvBufferFormat;
+                desc.colorFormat = _distortedUvBufferFormat;
 #pragma warning disable CS0618 // This method will be removed in a future release. Please use ReAllocateHandleIfNeeded instead. #from(2023.3)
                 RenderingUtils.ReAllocateIfNeeded(ref _distortedUvBufferRTHandle, desc);
 #pragma warning restore CS0618


### PR DESCRIPTION
# 概要

https://github.com/CyberAgentGameEntertainment/NovaShader/issues/176 の対応になります。

指摘して頂いている通り、RTのFormatの取得処理でGCAllocが発生しており、毎フレーム発生してしまうので対応しました。
また、Unity6のRenderGraphでも同様のことが発生しており、同様に対応しました。

# 動作確認

## Unity2022.3

### 対応前

GCAllocが発生しています。


<img width="1223" height="112" alt="2022Before" src="https://github.com/user-attachments/assets/c8668934-c1a2-4149-8fae-b312d50e94e8" />



### 対応後

GCAllocが発生しなくなっています。

<img width="1242" height="236" alt="2022After" src="https://github.com/user-attachments/assets/2e79144d-bbf1-45ca-a6cf-633eee7f6512" />



### 対応後の全体

全体通しても、GCAllocが発生しなくなっています。

<img width="1363" height="93" alt="2022Total" src="https://github.com/user-attachments/assets/533228dd-21e5-4dd9-846f-6b6d5d442405" />




## Unity6000.0 かつ、RenderGraph有効化

### 対応前

GCAllocが発生しています。

<img width="769" height="184" alt="6000Before" src="https://github.com/user-attachments/assets/334af0ce-0f29-4d62-afaa-47a75aa76023" />

### 対応後

GCAllocが発生しなくなっています。

<img width="768" height="321" alt="6000After" src="https://github.com/user-attachments/assets/dd91e7a7-8c61-43d3-a394-bea4dc2c102e" />


### 対応後の全体

全体通しても、GCAllocが発生しなくなっています。

<img width="885" height="90" alt="6000Total" src="https://github.com/user-attachments/assets/eaad16c9-664c-4386-936e-3ed1f8ed0a7a" />


# 確認したこと

- Profiler上でGCAllocが発生しないこと
    - 2022.3, 6000.0（RenderGraph対応）で確認
- テストが通ること
